### PR TITLE
fix: add XML sitemap generation with correct Content-Type header

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,7 @@ import react from '@astrojs/react';
 
 // https://astro.build/config
 export default defineConfig({
+  site: "https://knapgemaakt.nl",
   vite: {
     plugins: [tailwindcss()]
   },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://knapgemaakt.nl/sitemap.xml

--- a/src/components/ConceptShowcase.astro
+++ b/src/components/ConceptShowcase.astro
@@ -27,7 +27,7 @@ const projects: Project[] = [
         color: "bg-ink",
         colSpan: "md:col-span-6",
         image: "/fitcityculemborg.png",
-        url: "https://fitcityculemborg.summitlab.dev",
+        url: "https://fitcityculemborg.knapgemaakt.nl",
     },
     {
         title: "ByShakir",
@@ -36,7 +36,7 @@ const projects: Project[] = [
         color: "bg-ink",
         colSpan: "md:col-span-6",
         image: "/byshakir.png",
-        url: "https://byshakir.summitlab.dev",
+        url: "https://byshakir.knapgemaakt.nl",
     },
 ];
 ---

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,41 @@
+const site = import.meta.env.SITE ?? "https://knapgemaakt.nl";
+
+const staticPages = [
+  "/",
+  "/aanvragen",
+  "/algemene-voorwaarden",
+  "/privacy",
+  "/sitemap",
+];
+
+const cities = [
+  "Culemborg",
+  "Utrecht",
+  "Houten",
+  "Nieuwegein",
+  "Geldermalsen",
+  "Tiel",
+  "Vianen",
+  "IJsselstein",
+  "Beesd",
+  "Buren",
+];
+
+const cityPages = cities.map((city) => `/webdesign-${city.toLowerCase()}`);
+
+const urlEntries = [...staticPages, ...cityPages]
+  .map((path) => `  <url>\n    <loc>${site}${path}</loc>\n  </url>`)
+  .join("\n");
+
+const body = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+  `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+  `${urlEntries}\n` +
+  `</urlset>\n`;
+
+export function GET() {
+  return new Response(body, {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+    },
+  });
+}


### PR DESCRIPTION
## Description

Fix for Google Search Console reporting sitemap as HTML instead of XML.

## Changes

- Create `sitemap.xml.ts` API route that generates proper XML sitemap
- Add `Content-Type: application/xml` header for search engines
- Include all static pages and dynamic city-based service pages
- Add `robots.txt` to explicitly reference sitemap location for crawlers
- Update project URLs in ConceptShowcase from summitlab.dev to knapgemaakt.nl

## Testing

- Built project successfully
- Verified sitemap.xml generates correctly with proper XML structure
- Confirmed Content-Type header is set to application/xml
- Sitemap includes all 15 pages (5 static + 10 city pages)

## Related

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)