### PR TITLE
fix: adjust text wrapping on aanvragen page to break after first sentence (#21)

### DIFF
--- a/src/pages/aanvragen.astro
+++ b/src/pages/aanvragen.astro
@@ -16,8 +16,8 @@ import { TextReveal } from "../components/TextReveal";
                 <p
                     class="text-xl md:text-2xl text-ink/60 font-medium max-w-4xl leading-relaxed"
                 >
-                    Vul het formulier in en wij nemen zo snel mogelijk contact
-                    met je op. Geen verplichtingen, wel direct actie.
+                    Vul het formulier in en wij nemen zo snel mogelijk contact met je op.<br />
+                    Geen verplichtingen, wel direct actie.
                 </p>
             </div>
 


### PR DESCRIPTION
- Added line break after first sentence for better readability
- Text now breaks after: 'Vul het formulier in en wij nemen zo snel mogelijk contact met je op.'
- Second sentence appears on new line: 'Geen verplichtingen, wel direct actie.'
- Consistent across all responsive viewports

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
