### PR TITLE
fix: normalize datetime comparisons in booking queries

### DIFF
--- a/src/pages/api/availability-month.ts
+++ b/src/pages/api/availability-month.ts
@@ -27,12 +27,12 @@ export const GET: APIRoute = async ({ request, locals }) => {
 
     // Fetch all bookings for the month
     const bookings = await db.prepare(
-      'SELECT start_time, end_time FROM bookings WHERE status = ? AND start_time >= ? AND start_time <= ?'
+      'SELECT start_time, end_time FROM bookings WHERE status = ? AND datetime(start_time) >= datetime(?) AND datetime(start_time) <= datetime(?)'
     ).bind('confirmed', monthStart.toISOString(), monthEnd.toISOString()).all();
 
     // Fetch all blocked times for the month
     const blockedTimes = await db.prepare(
-      'SELECT start_time, end_time FROM blocked_times WHERE start_time >= ? AND start_time <= ?'
+      'SELECT start_time, end_time FROM blocked_times WHERE datetime(start_time) >= datetime(?) AND datetime(start_time) <= datetime(?)'
     ).bind(monthStart.toISOString(), monthEnd.toISOString()).all();
 
     return new Response(JSON.stringify({

--- a/src/pages/api/availability.ts
+++ b/src/pages/api/availability.ts
@@ -66,12 +66,12 @@ export const GET: APIRoute = async ({ request, locals }) => {
     endOfDay.setHours(23, 59, 59, 999);
 
     const bookedSlots = await db.prepare(
-      'SELECT start_time, end_time FROM bookings WHERE status = ? AND start_time >= ? AND start_time < ?'
+      'SELECT start_time, end_time FROM bookings WHERE status = ? AND datetime(start_time) >= datetime(?) AND datetime(start_time) < datetime(?)'
     ).bind('confirmed', startOfDay.toISOString(), endOfDay.toISOString()).all();
 
     // Get blocked times
     const blockedSlots = await db.prepare(
-      'SELECT start_time, end_time FROM blocked_times WHERE start_time >= ? AND start_time < ?'
+      'SELECT start_time, end_time FROM blocked_times WHERE datetime(start_time) >= datetime(?) AND datetime(start_time) < datetime(?)'
     ).bind(startOfDay.toISOString(), endOfDay.toISOString()).all();
 
     // Filter out unavailable slots (booked, blocked, too soon, or too far in advance)


### PR DESCRIPTION
Fixes #28

## Changes
- Use SQLite's `datetime()` function to normalize ISO 8601 timestamps (with or without timezone offsets) before comparison
- Add debug logging to capture query parameters and results for troubleshooting
- Apply fix across all booking-related APIs: bookings, availability, and availability-month

## Root Cause
The issue was caused by inconsistent datetime format handling:
- Database storage: Blocked times stored with timezone offsets (e.g., `2026-01-20T08:00:00+01:00`)
- API queries: Using `.toISOString()` which produces UTC format (e.g., `2026-01-20T07:00:00.000Z`)

SQLite's text-based datetime comparison doesn't handle mixed formats correctly, leading to false positives.

## Testing
- Build completed successfully
- All three API endpoints now use consistent datetime normalization
- Preview tested on `test/28-fix-false-positive-blocked-time` branch

Closes #28