### PR TITLE
fix: resolve 500 error on city landing pages

### DIFF
--- a/src/pages/webdesign-[city].astro
+++ b/src/pages/webdesign-[city].astro
@@ -6,7 +6,17 @@ import OfferSection from "../components/OfferSection.astro";
 import ConceptShowcase from "../components/ConceptShowcase.astro";
 import { TextReveal } from "../components/TextReveal";
 
+export const prerender = true;
+
 export function getStaticPaths() {
+    // Get available city images at build time
+    const cityImages = import.meta.glob("/public/cities/*.webp");
+    const availableCityImages = new Set(
+        Object.keys(cityImages).map((path) =>
+            path.replace("/public/cities/", "").replace(".webp", ""),
+        ),
+    );
+
     const cities = [
         "Culemborg",
         "Utrecht",
@@ -22,25 +32,16 @@ export function getStaticPaths() {
 
     return cities.map((city) => ({
         params: { city: city.toLowerCase() },
-        props: { city },
+        props: {
+            city,
+            hasCityImage: availableCityImages.has(city.toLowerCase()),
+        },
     }));
 }
 
-const { city } = Astro.props;
-
-// Check if specific city image exists
-import fs from "node:fs";
-import path from "node:path";
+const { city, hasCityImage } = Astro.props;
 
 const cityImageFilename = `${city.toLowerCase()}.webp`;
-const cityImagePath = path.join(
-    process.cwd(),
-    "public",
-    "cities",
-    cityImageFilename,
-);
-const hasCityImage = fs.existsSync(cityImagePath);
-
 const mapImage = hasCityImage
     ? `/cities/${cityImageFilename}`
     : "/city_map.webp";


### PR DESCRIPTION
## Summary
- Removed Node.js `fs` module usage that was incompatible with Cloudflare Workers
- Added `export const prerender = true` to statically generate city pages at build time
- Used `import.meta.glob()` to detect city images at build time

Closes #33