### PR TITLE
fix: fix heading hierarchy in OfferSection for accessibility

### DIFF
--- a/src/components/OfferSection.astro
+++ b/src/components/OfferSection.astro
@@ -106,12 +106,12 @@ const retainerFeatures = [
                 {
                     coreFeatures.map((feature) => (
                         <div class="flex flex-col">
-                            <h3 class="text-2xl font-black uppercase tracking-tighter mb-6 flex items-center gap-3">
+                            <h2 class="text-2xl font-black uppercase tracking-tighter mb-6 flex items-center gap-3">
                                 <span class="text-electric font-mono text-xl">
                                     [+]
                                 </span>
                                 {feature.title}
-                            </h3>
+                            </h2>
                             <ul class="space-y-4">
                                 {feature.points.map((point) => (
                                     <li class="flex items-start gap-3 text-lg font-medium leading-tight text-ink/80">
@@ -135,9 +135,9 @@ const retainerFeatures = [
             noHover={true}
             className="p-4 md:p-12 border-t border-ink/10 bg-ink text-canvas"
         >
-            <h3 class="text-2xl font-black uppercase tracking-tighter mb-8">
+            <h2 class="text-2xl font-black uppercase tracking-tighter mb-8">
                 Jouw Voordeel Op Een Rij
-            </h3>
+            </h2>
             <div class="w-full overflow-x-auto">
                 <table class="w-full text-left border-collapse">
                     <thead>
@@ -298,11 +298,11 @@ const retainerFeatures = [
                 >
                     Het Beheerpakket
                 </div>
-                <h3
+                <h2
                     class="text-3xl md:text-5xl font-black uppercase tracking-tighter mb-6 italic leading-[0.9]"
                 >
                     Alles Van A Tot Z Geregeld.
-                </h3>
+                </h2>
                 <div
                     class="font-mono text-sm text-electric uppercase tracking-widest mb-10"
                 >


### PR DESCRIPTION
## Summary
- Changed `h3` elements to `h2` in OfferSection.astro for proper heading hierarchy
- Fixes accessibility audit warning about headings not being in sequentially-descending order
- Affects 3 headings: core features, comparison table, and retainer section

## Test plan
- [x] Build passes
- [ ] Run Lighthouse accessibility audit to verify heading order issue is resolved

Closes #43

🤖 Generated with [Claude Code](https://claude.ai/code)