### PR TITLE
feat: optimize critical request chain for faster page load

### DIFF
--- a/src/components/HorizontalProjectScroll.astro
+++ b/src/components/HorizontalProjectScroll.astro
@@ -35,4 +35,4 @@ const projects = [
 ];
 ---
 
-<HorizontalProjectScroll client:load projects={projects} />
+<HorizontalProjectScroll client:visible projects={projects} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -62,18 +62,18 @@ import { TextReveal } from "../components/TextReveal";
 				>
 					<div class="flex flex-col items-center justify-center py-4">
 						<TextReveal
-							client:load
+							client:visible
 							text="Jouw Nieuwe Website."
 							className="text-4xl md:text-9xl font-bold uppercase tracking-tighter leading-[0.9] text-center"
 						/>
 						<TextReveal
-							client:load
+							client:visible
 							text="In 7 Dagen."
 							delay={0.2}
 							className="text-[10vw] md:text-9xl font-bold uppercase tracking-tighter leading-[0.9] text-center"
 						/>
 						<TextReveal
-							client:load
+							client:visible
 							text="€595."
 							delay={0.4}
 							className="text-6xl md:text-9xl font-bold uppercase tracking-tighter leading-[0.9] text-center text-electric"
@@ -87,7 +87,7 @@ import { TextReveal } from "../components/TextReveal";
 					rowSpan="md:row-span-6"
 					className="relative p-0 border-l border-ink/10 md:border-l-0 overflow-hidden"
 				>
-					<VisualCard client:load />
+					<VisualCard client:visible />
 				</BentoItem>
 			</BentoGrid>
 		</div>

--- a/src/pages/webdesign-[city].astro
+++ b/src/pages/webdesign-[city].astro
@@ -152,7 +152,7 @@ const mapImage = hasCityImage
         </section>
     </main>
 
-    <HorizontalProjectScroll client:load />
+    <HorizontalProjectScroll client:visible />
 
     <OfferSection />
 </Layout>


### PR DESCRIPTION
## Summary
- Changed `client:load` to `client:visible` for non-critical components
- Affects: TextReveal (3x), VisualCard, HorizontalProjectScroll
- JavaScript now loads only when components enter the viewport, reducing critical request chain

## Files changed
- `src/pages/index.astro` - defer hydration for hero animations and visual card
- `src/pages/webdesign-[city].astro` - defer HorizontalProjectScroll
- `src/components/HorizontalProjectScroll.astro` - defer internal React component

## Test plan
- [ ] Run Lighthouse audit to verify reduced critical request chain
- [ ] Verify animations still trigger correctly when scrolling into view
- [ ] Check all pages render without hydration errors

Closes #44

🤖 Generated with [Claude Code](https://claude.ai/code)