### PR TITLE
fix: reduce CLS from Inter Tight font loading

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,8 @@
 ---
-import "@fontsource/inter-tight";
+import "@fontsource/inter-tight/400.css";
+import "@fontsource/inter-tight/500.css";
+import "@fontsource/inter-tight/700.css";
+import "@fontsource/inter-tight/900.css";
 import "../styles/global.css";
 import { ViewTransitions } from "astro:transitions";
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,12 +1,23 @@
 @import "tailwindcss";
 
+/* Metric-adjusted fallback font to minimize CLS when Inter Tight loads
+   These values approximate Inter Tight's metrics using Arial as base */
+@font-face {
+  font-family: 'Inter Tight Fallback';
+  src: local('Arial');
+  size-adjust: 107%;
+  ascent-override: 90%;
+  descent-override: 22%;
+  line-gap-override: 0%;
+}
+
 @theme {
   --color-canvas: #FFFFFF;
   --color-ink: #000000;
   --color-acid: #CCFF00;
   --color-electric: #7C3AED;
 
-  --font-sans: "Inter Tight", system-ui, sans-serif;
+  --font-sans: "Inter Tight", "Inter Tight Fallback", system-ui, sans-serif;
   --font-display: "Helvetica Now Display", "Inter Tight", sans-serif;
 }
 


### PR DESCRIPTION
## Summary
- Import specific font weights (400, 500, 700, 900) instead of default fontsource import
- Add metric-adjusted fallback font (`Inter Tight Fallback`) based on Arial to minimize layout shift during font swap
- Update font stack to use the fallback before system fonts

## Test plan
- [x] Build succeeds
- [x] Font weights display correctly (font-black now uses actual 900 weight)
- [ ] Verify reduced CLS in Lighthouse after deployment

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)