### PR TITLE
perf: improve FCP, LCP, and Speed Index (#52)

### DIFF
--- a/src/components/SmoothScroll.tsx
+++ b/src/components/SmoothScroll.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import Lenis from "lenis";
+
+export function SmoothScroll() {
+    useEffect(() => {
+        const lenis = new Lenis({
+            lerp: 0.1,
+            smoothWheel: true,
+        });
+
+        function raf(time: number) {
+            lenis.raf(time);
+            requestAnimationFrame(raf);
+        }
+
+        requestAnimationFrame(raf);
+
+        return () => {
+            lenis.destroy();
+        };
+    }, []);
+
+    return null;
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,6 +5,10 @@ import "@fontsource/inter-tight/700.css";
 import "@fontsource/inter-tight/900.css";
 import "../styles/global.css";
 import { ViewTransitions } from "astro:transitions";
+import { SmoothScroll } from "../components/SmoothScroll";
+
+// Import critical font file for preloading (hero text uses 900 weight)
+import interTight900 from "@fontsource/inter-tight/files/inter-tight-latin-900-normal.woff2";
 
 interface Props {
   title: string;
@@ -23,6 +27,8 @@ const { title } = Astro.props;
     />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon_final.svg" />
+    <!-- Preload critical font for hero text (LCP optimization) -->
+    <link rel="preload" href={interTight900} as="font" type="font/woff2" crossorigin />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
     <ViewTransitions />
@@ -31,21 +37,7 @@ const { title } = Astro.props;
     class="bg-canvas text-ink antialiased overflow-x-hidden selection:bg-acid selection:text-black"
   >
     <slot />
-
-    <script>
-      import Lenis from "lenis";
-
-      const lenis = new Lenis({
-        lerp: 0.1, // "Viscous" feel
-        smoothWheel: true,
-      });
-
-      function raf(time: number) {
-        lenis.raf(time);
-        requestAnimationFrame(raf);
-      }
-
-      requestAnimationFrame(raf);
-    </script>
+    <!-- Defer smooth scroll initialization until browser is idle (FCP optimization) -->
+    <SmoothScroll client:idle />
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Add `<link rel="preload">` for Inter Tight 900 font (hero text) to speed up LCP
- Move Lenis smooth scroll from synchronous inline script to `client:idle` React component
- Lenis (~17KB) now defers loading until browser is idle, unblocking FCP

## Expected Improvements
| Metric | Before | Target |
|--------|--------|--------|
| FCP | 1.8s | <1.0s |
| LCP | 2.6s | <1.5s |
| Speed Index | 4.3s | <2.0s |

## Test plan
- [ ] Verify font preload appears in Network tab (high priority)
- [ ] Verify Lenis loads after page is interactive
- [ ] Run Lighthouse audit to measure improvements
- [ ] Test smooth scroll still works

Closes #52

🤖 Generated with [Claude Code](https://claude.ai/code)