### PR TITLE
fix: fix render-blocking CSS (#55)

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import Layout from "../layouts/Layout.astro";
 ---
 

--- a/src/pages/algemene-voorwaarden.astro
+++ b/src/pages/algemene-voorwaarden.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import Layout from "../layouts/Layout.astro";
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import Layout from "../layouts/Layout.astro";
 import BentoGrid from "../components/BentoGrid.astro";
 import BentoItem from "../components/BentoItem.astro";

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import Layout from "../layouts/Layout.astro";
 ---
 


### PR DESCRIPTION
## Summary
- Enable static prerendering on all pages (404, algemene-voorwaarden, index, privacy)
- This allows CSS to be properly inlined/optimized at build time, eliminating render-blocking CSS

Closes #55