### PR TITLE
fix: remove redundant client:visible from HorizontalProjectScroll (#57)

### DIFF
--- a/src/pages/webdesign-[city].astro
+++ b/src/pages/webdesign-[city].astro
@@ -152,7 +152,7 @@ const mapImage = hasCityImage
         </section>
     </main>
 
-    <HorizontalProjectScroll client:visible />
+    <HorizontalProjectScroll />
 
     <OfferSection />
 </Layout>


### PR DESCRIPTION
## Summary
- Removed redundant `client:visible` directive from `webdesign-[city].astro`
- The Astro wrapper component already applies `client:visible` to the React component internally

Closes #57