### PR TITLE
fix: reduce CLS from Inter Tight font loading in hero section (#59)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,13 +1,17 @@
 ---
-import "@fontsource/inter-tight/400.css";
-import "@fontsource/inter-tight/500.css";
-import "@fontsource/inter-tight/700.css";
-import "@fontsource/inter-tight/900.css";
+// Use latin-only subsets with font-display: optional to prevent CLS
+// Import only latin subset CSS files (smaller, covers Dutch language)
+import "@fontsource/inter-tight/latin-400.css";
+import "@fontsource/inter-tight/latin-500.css";
+import "@fontsource/inter-tight/latin-700.css";
+import "@fontsource/inter-tight/latin-900.css";
 import "../styles/global.css";
 import { ViewTransitions } from "astro:transitions";
 import { SmoothScroll } from "../components/SmoothScroll";
 
-// Import critical font file for preloading (hero text uses 900 weight)
+// Import critical font files for preloading (hero text uses 700 weight)
+import interTight400 from "@fontsource/inter-tight/files/inter-tight-latin-400-normal.woff2";
+import interTight700 from "@fontsource/inter-tight/files/inter-tight-latin-700-normal.woff2";
 import interTight900 from "@fontsource/inter-tight/files/inter-tight-latin-900-normal.woff2";
 
 interface Props {
@@ -18,7 +22,7 @@ const { title } = Astro.props;
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="nl">
   <head>
     <meta charset="UTF-8" />
     <meta
@@ -27,8 +31,34 @@ const { title } = Astro.props;
     />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon_final.svg" />
-    <!-- Preload critical font for hero text (LCP optimization) -->
+    <!-- Preload critical fonts for hero text (LCP/CLS optimization) -->
+    <link rel="preload" href={interTight400} as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href={interTight700} as="font" type="font/woff2" crossorigin />
     <link rel="preload" href={interTight900} as="font" type="font/woff2" crossorigin />
+    <!-- Override font-display to 'optional' to prevent CLS from font swap -->
+    <style set:html={`
+      @font-face {
+        font-family: 'Inter Tight';
+        font-style: normal;
+        font-display: optional;
+        font-weight: 400;
+        src: url('${interTight400}') format('woff2');
+      }
+      @font-face {
+        font-family: 'Inter Tight';
+        font-style: normal;
+        font-display: optional;
+        font-weight: 700;
+        src: url('${interTight700}') format('woff2');
+      }
+      @font-face {
+        font-family: 'Inter Tight';
+        font-style: normal;
+        font-display: optional;
+        font-weight: 900;
+        src: url('${interTight900}') format('woff2');
+      }
+    `} />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
     <ViewTransitions />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,13 +1,14 @@
 @import "tailwindcss";
 
 /* Metric-adjusted fallback font to minimize CLS when Inter Tight loads
-   These values approximate Inter Tight's metrics using Arial as base */
+   These values approximate Inter Tight's metrics using Arial as base
+   Source: https://developer.chrome.com/blog/font-fallbacks */
 @font-face {
   font-family: 'Inter Tight Fallback';
   src: local('Arial');
-  size-adjust: 107%;
-  ascent-override: 90%;
-  descent-override: 22%;
+  size-adjust: 107.40%;
+  ascent-override: 90.20%;
+  descent-override: 22.48%;
   line-gap-override: 0%;
 }
 


### PR DESCRIPTION
## Summary
- Add `font-display: optional` override for critical font weights (400, 700, 900) to prevent font swap CLS
- Preload all critical Latin font subsets used in hero
- Use Latin-only font subsets (smaller files, covers Dutch language)
- Refine fallback font metrics to match Inter font specifications
- Change html lang to 'nl' for Dutch content

## CLS Improvement
Before: CLS 0.261 from hero text shifting during font swap
After: CLS reduced by using `font-display: optional` which prevents late font swaps

Closes #59