### PR TITLE
perf: enable clientPrerender for speculative link preloading ⚡

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -18,5 +18,9 @@ export default defineConfig({
     plugins: [tailwindcss()]
   },
 
-  integrations: [react()]
+  integrations: [react()],
+
+  experimental: {
+    clientPrerender: true
+  }
 });


### PR DESCRIPTION
## Summary
- Enables experimental `clientPrerender` feature in astro.config.mjs
- Uses browser's Speculation Rules API to prerender links users are likely to click
- Improves perceived navigation speed

## Investigation Results
Audited potential optimizations from SEO checklist:
- **client:* directives**: Already optimal (no `client:load`, all use `client:visible` or `client:idle`)
- **Font preloading**: Already implemented in Layout.astro
- **clientPrerender**: Now enabled ✅

The JS chain in Lighthouse audit is inherent to ES module dependencies, not something fixable at config level.

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)