### PR TITLE
fix(lcp): keep TextReveal text visible during hydration

### DIFF
--- a/src/components/TextReveal.tsx
+++ b/src/components/TextReveal.tsx
@@ -16,7 +16,7 @@ export function TextReveal({ text, className, delay = 0, as: Tag = "div" }: Prop
     const words = text.split(" ");
 
     const container = {
-        hidden: { opacity: 0 },
+        hidden: { opacity: 1 },
         visible: (i = 1) => ({
             opacity: 1,
             transition: { staggerChildren: 0.12, delayChildren: 0.04 * i + delay },
@@ -25,7 +25,7 @@ export function TextReveal({ text, className, delay = 0, as: Tag = "div" }: Prop
 
     const child = {
         hidden: {
-            opacity: 0,
+            opacity: 1,
             y: 20,
             transition: {
                 type: "spring",


### PR DESCRIPTION
## Summary
- Changed `TextReveal` component's hidden state opacity from `0` to `1`
- Hero text now renders immediately without waiting for JS hydration
- Subtle y-axis slide animation still plays when React hydrates

## Problem
The hero text ("Jouw Nieuwe Website. In 7 Dagen. €595.") started invisible (`opacity: 0`) and only became visible after React hydrated. Since this is the largest content above the fold, it was delaying LCP until JavaScript executed.

## Solution
Keep text visible immediately, only animate the `y` position:
```tsx
// Before: Text hidden until JS runs
hidden: { opacity: 0, y: 20 }

// After: Text visible, only position animates
hidden: { opacity: 1, y: 20 }
```

Closes #63

🤖 Generated with [Claude Code](https://claude.ai/code)