### PR TITLE
fix(fonts): remove duplicate @fontsource CSS imports

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,10 +1,6 @@
 ---
-// Use latin-only subsets with font-display: optional to prevent CLS
-// Import only latin subset CSS files (smaller, covers Dutch language)
-import "@fontsource/inter-tight/latin-400.css";
-import "@fontsource/inter-tight/latin-500.css";
-import "@fontsource/inter-tight/latin-700.css";
-import "@fontsource/inter-tight/latin-900.css";
+// Font CSS is handled by custom @font-face declarations below with font-display: optional
+// This avoids duplicate declarations from @fontsource CSS imports
 import "../styles/global.css";
 import { ViewTransitions } from "astro:transitions";
 import { SmoothScroll } from "../components/SmoothScroll";


### PR DESCRIPTION
## Summary
- Removed redundant `@fontsource` CSS imports from Layout.astro
- Custom `@font-face` declarations with `font-display: optional` already handle font loading
- woff2 files continue to be preloaded separately

## Problem
Duplicate @font-face declarations were causing a 270ms element render delay:
1. @fontsource CSS imports used `font-display: swap`
2. Custom @font-face used `font-display: optional`

Browser was processing competing rules for the same font.

## LCP breakdown before
- TTFB: 0ms
- Element render delay: 270ms ⚠️

Closes #65

🤖 Generated with [Claude Code](https://claude.ai/code)