### PR TITLE
fix(fonts): restore critical 900 weight import to prevent CLS

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,14 +1,14 @@
 ---
-// Font CSS is handled by custom @font-face declarations below with font-display: optional
-// This avoids duplicate declarations from @fontsource CSS imports
+// Import only critical font weight (900) for LCP element "KNAP GEMAAKT." to prevent CLS
+// Other weights use custom @font-face with font-display: optional below
+import "@fontsource/inter-tight/latin-900.css";
 import "../styles/global.css";
 import { ViewTransitions } from "astro:transitions";
 import { SmoothScroll } from "../components/SmoothScroll";
 
-// Import critical font files for preloading (hero text uses 700 weight)
+// Import font files for preloading (400, 700 only - 900 handled by @fontsource import)
 import interTight400 from "@fontsource/inter-tight/files/inter-tight-latin-400-normal.woff2";
 import interTight700 from "@fontsource/inter-tight/files/inter-tight-latin-700-normal.woff2";
-import interTight900 from "@fontsource/inter-tight/files/inter-tight-latin-900-normal.woff2";
 
 interface Props {
   title: string;
@@ -27,11 +27,10 @@ const { title } = Astro.props;
     />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon_final.svg" />
-    <!-- Preload critical fonts for hero text (LCP/CLS optimization) -->
+    <!-- Preload fonts 400/700 (900 handled by @fontsource CSS import) -->
     <link rel="preload" href={interTight400} as="font" type="font/woff2" crossorigin />
     <link rel="preload" href={interTight700} as="font" type="font/woff2" crossorigin />
-    <link rel="preload" href={interTight900} as="font" type="font/woff2" crossorigin />
-    <!-- Override font-display to 'optional' to prevent CLS from font swap -->
+    <!-- Custom @font-face for 400/700 with font-display: optional (non-critical weights) -->
     <style set:html={`
       @font-face {
         font-family: 'Inter Tight';
@@ -46,13 +45,6 @@ const { title } = Astro.props;
         font-display: optional;
         font-weight: 700;
         src: url('${interTight700}') format('woff2');
-      }
-      @font-face {
-        font-family: 'Inter Tight';
-        font-style: normal;
-        font-display: optional;
-        font-weight: 900;
-        src: url('${interTight900}') format('woff2');
       }
     `} />
     <meta name="generator" content={Astro.generator} />


### PR DESCRIPTION
## Summary
- Restored `@fontsource/inter-tight/latin-900.css` import for LCP element
- Removed duplicate 900 weight from custom @font-face declarations
- Keeps 400/700 with `font-display: optional` (non-critical weights)

## Problem
After removing all @fontsource imports in #65, CLS increased to 0.260 because the critical font for "KNAP GEMAAKT." wasn't loading synchronously.

## Solution
| Weight | Source | font-display | Purpose |
|--------|--------|--------------|---------|
| **900** | @fontsource CSS import | `swap` | LCP element - prevents CLS |
| 700 | Custom @font-face + preload | `optional` | Secondary text |
| 400 | Custom @font-face + preload | `optional` | Body text |

Closes #67

🤖 Generated with [Claude Code](https://claude.ai/code)