### PR TITLE
fix(fonts): import 700 weight via @fontsource to fix TextReveal CLS

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,14 +1,14 @@
 ---
-// Import only critical font weight (900) for LCP element "KNAP GEMAAKT." to prevent CLS
-// Other weights use custom @font-face with font-display: optional below
+// Import critical font weights via @fontsource to prevent CLS on hero elements
+// 900: "KNAP GEMAAKT." logo | 700: TextReveal hero text
+import "@fontsource/inter-tight/latin-700.css";
 import "@fontsource/inter-tight/latin-900.css";
 import "../styles/global.css";
 import { ViewTransitions } from "astro:transitions";
 import { SmoothScroll } from "../components/SmoothScroll";
 
-// Import font files for preloading (400, 700 only - 900 handled by @fontsource import)
+// Import font file for preloading (400 only - 700/900 handled by @fontsource imports)
 import interTight400 from "@fontsource/inter-tight/files/inter-tight-latin-400-normal.woff2";
-import interTight700 from "@fontsource/inter-tight/files/inter-tight-latin-700-normal.woff2";
 
 interface Props {
   title: string;
@@ -27,10 +27,9 @@ const { title } = Astro.props;
     />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon_final.svg" />
-    <!-- Preload fonts 400/700 (900 handled by @fontsource CSS import) -->
+    <!-- Preload font 400 (700/900 handled by @fontsource CSS imports) -->
     <link rel="preload" href={interTight400} as="font" type="font/woff2" crossorigin />
-    <link rel="preload" href={interTight700} as="font" type="font/woff2" crossorigin />
-    <!-- Custom @font-face for 400/700 with font-display: optional (non-critical weights) -->
+    <!-- Custom @font-face for 400 with font-display: optional (body text, non-critical) -->
     <style set:html={`
       @font-face {
         font-family: 'Inter Tight';
@@ -38,13 +37,6 @@ const { title } = Astro.props;
         font-display: optional;
         font-weight: 400;
         src: url('${interTight400}') format('woff2');
-      }
-      @font-face {
-        font-family: 'Inter Tight';
-        font-style: normal;
-        font-display: optional;
-        font-weight: 700;
-        src: url('${interTight700}') format('woff2');
       }
     `} />
     <meta name="generator" content={Astro.generator} />


### PR DESCRIPTION
## Summary
- Added `@fontsource/inter-tight/latin-700.css` import for TextReveal hero text
- Removed custom @font-face for 700 to avoid duplicate declarations
- Only weight 400 now uses custom @font-face with `font-display: optional`

## Font Strategy

| Weight | Source | font-display | Used by |
|--------|--------|--------------|---------|
| **700** | @fontsource CSS | `swap` | TextReveal hero text |
| **900** | @fontsource CSS | `swap` | "KNAP GEMAAKT." logo |
| 400 | Custom @font-face | `optional` | Body text |

## Problem
CLS of 0.261 was occurring on TextReveal hero text because weight 700 was using `font-display: optional` causing font swap.

Closes #69

🤖 Generated with [Claude Code](https://claude.ai/code)