### PR TITLE
fix(cls): replace React TextReveal with CSS animation

### DIFF
--- a/src/components/TextRevealCSS.astro
+++ b/src/components/TextRevealCSS.astro
@@ -1,0 +1,49 @@
+---
+interface Props {
+  text: string;
+  class?: string;
+  delay?: number;
+  as?: 'h1' | 'h2' | 'h3' | 'div' | 'span';
+}
+
+const { text, class: className = '', delay = 0, as: Tag = 'div' } = Astro.props;
+const words = text.split(' ');
+const baseDelay = delay;
+const staggerDelay = 0.12; // seconds between each word
+---
+
+<Tag class:list={['inline-block', className]}>
+  {words.map((word, index) => (
+    <span
+      class="text-reveal-word"
+      style={`animation-delay: ${baseDelay + (index * staggerDelay)}s`}
+    >
+      {word}
+    </span>
+  ))}
+</Tag>
+
+<style>
+  @keyframes textReveal {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .text-reveal-word {
+    display: inline-block;
+    margin-right: 0.25em;
+    opacity: 0;
+    transform: translateY(20px);
+    animation: textReveal 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+  }
+
+  .text-reveal-word:last-child {
+    margin-right: 0;
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,7 @@ import { VisualCard } from "../components/VisualCard";
 import OfferSection from "../components/OfferSection.astro";
 import HorizontalProjectScroll from "../components/HorizontalProjectScroll.astro";
 import Footer from "../components/Footer.astro";
-import { TextReveal } from "../components/TextReveal";
+import TextRevealCSS from "../components/TextRevealCSS.astro";
 ---
 
 <Layout title="KNAP GEMAAKT.">
@@ -63,22 +63,19 @@ import { TextReveal } from "../components/TextReveal";
 					className="flex items-center justify-center p-8 md:p-16 border-t border-ink/10 md:border-t-0"
 				>
 					<div class="flex flex-col items-center justify-center py-4">
-						<TextReveal
-							client:visible
+						<TextRevealCSS
 							text="Jouw Nieuwe Website."
-							className="text-4xl md:text-9xl font-bold uppercase tracking-tighter leading-[0.9] text-center"
+							class="text-4xl md:text-9xl font-bold uppercase tracking-tighter leading-[0.9] text-center"
 						/>
-						<TextReveal
-							client:visible
+						<TextRevealCSS
 							text="In 7 Dagen."
 							delay={0.2}
-							className="text-[10vw] md:text-9xl font-bold uppercase tracking-tighter leading-[0.9] text-center"
+							class="text-[10vw] md:text-9xl font-bold uppercase tracking-tighter leading-[0.9] text-center"
 						/>
-						<TextReveal
-							client:visible
+						<TextRevealCSS
 							text="€595."
 							delay={0.4}
-							className="text-6xl md:text-9xl font-bold uppercase tracking-tighter leading-[0.9] text-center text-electric"
+							class="text-6xl md:text-9xl font-bold uppercase tracking-tighter leading-[0.9] text-center text-electric"
 						/>
 					</div>
 				</BentoItem>


### PR DESCRIPTION
## Summary
- Created `TextRevealCSS.astro` component using pure CSS `@keyframes`
- Replaced React/Framer Motion TextReveal on homepage
- No JavaScript hydration = No CLS

## How it works

```css
@keyframes textReveal {
  from { opacity: 0; transform: translateY(20px); }
  to { opacity: 1; transform: translateY(0); }
}
```

- Pure CSS animation, no React
- Staggered word animation via `animation-delay`
- Same visual effect as before

## Problem
React hydration of Framer Motion TextReveal was causing CLS of 0.260.

## Solution
CSS animations don't require hydration, so no layout shift occurs.

Closes #73

🤖 Generated with [Claude Code](https://claude.ai/code)