### PR TITLE
feat: swap portfolio section position on homepage

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -47,7 +47,7 @@ import { TextReveal } from "./TextReveal";
                 <div
                     class="mt-8 md:mt-0 font-mono text-xs md:text-sm text-canvas/60 whitespace-nowrap md:absolute md:top-6 md:right-6"
                 >
-                    © 2026 Knap Gemaakt.
+                    © 2026 KNAP GEMAAKT.
                 </div>
             </div>
         </BentoItem>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -91,9 +91,8 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 			</BentoGrid>
 		</div>
 
-		<OfferSection />
-		<!-- <PortfolioSection /> -->
 		<HorizontalProjectScroll />
+		<OfferSection />
 		<Footer />
 	</main>
 </Layout>


### PR DESCRIPTION
## Summary
- Move portfolio section (`HorizontalProjectScroll`) before `OfferSection` on homepage to match location pages layout
- Capitalize footer copyright text to `© 2026 KNAP GEMAAKT.`

Closes #75