### PR TITLE
fix: improve homepage title to proper SEO length

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,7 @@ import Footer from "../components/Footer.astro";
 import TextRevealCSS from "../components/TextRevealCSS.astro";
 ---
 
-<Layout title="KNAP GEMAAKT.">
+<Layout title="Jouw Nieuwe Website in 7 Dagen. €595 | Knap Gemaakt">
 	<main class="bg-canvas">
 		<div class="min-h-screen p-4 md:p-8 pb-0">
 			<BentoGrid class="h-[95vh]">


### PR DESCRIPTION
## Summary
- Expand homepage title from 13 to 52 characters (target: 50-60)
- Include value proposition and brand name

**Before:** `KNAP GEMAAKT.` (13 chars)
**After:** `Jouw Nieuwe Website in 7 Dagen. €595 | Knap Gemaakt` (52 chars)