### PR TITLE
feat: update aanvragen confirmation copy for self-booking flow

### DIFF
--- a/src/pages/aanvragen.astro
+++ b/src/pages/aanvragen.astro
@@ -16,8 +16,8 @@ import { TextReveal } from "../components/TextReveal";
                 <p
                     class="text-xl md:text-2xl text-ink/60 font-medium max-w-4xl leading-relaxed"
                 >
-                    Vul het formulier in en wij nemen zo snel mogelijk contact
-                    met je op.<br />
+                    Vul het formulier in en plan direct een vrijblijvend
+                    gesprek.<br />
                     Geen verplichtingen, wel direct actie.
                 </p>
             </div>
@@ -355,8 +355,8 @@ import { TextReveal } from "../components/TextReveal";
                         Aanvraag Ontvangen
                     </h2>
                     <p class="text-xl text-ink/60 max-w-lg mx-auto">
-                        Bedankt voor je aanvraag. We nemen zo snel mogelijk
-                        contact met je op.
+                        Bedankt voor je aanvraag! Je gesprek is ingepland.
+                        Check je inbox voor de bevestiging.
                     </p>
                     <a
                         href="/"


### PR DESCRIPTION
## Summary
- Updated form intro to say "plan direct een vrijblijvend gesprek" instead of "wij nemen contact met je op"
- Updated success message to confirm the booked appointment: "Je gesprek is ingepland. Check je inbox voor de bevestiging"
- Kept the submit footnote unchanged ("We bellen je op het gekozen tijdstip") as it clearly explains what happens when they pick a time

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)