### PR TITLE
chore: polish hero section and unify CTA copy 🔧

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -60,7 +60,7 @@ const isActive = (href: string) => {
                     href="/aanvragen"
                     class="bg-acid text-ink px-5 py-2.5 font-bold uppercase tracking-tight text-sm hover:bg-ink hover:text-acid transition-colors duration-300"
                 >
-                    Gratis Gesprek
+                    Kennismaking
                 </a>
             </nav>
 
@@ -95,7 +95,7 @@ const isActive = (href: string) => {
             </a>
         ))}
         <a href="/aanvragen" class="nav-link block bg-acid text-ink px-5 py-4 font-bold uppercase tracking-tight text-center mt-6 hover:bg-ink hover:text-acid transition-colors duration-300">
-            Gratis Gesprek
+            Kennismaking
         </a>
     </nav>
 </header>

--- a/src/components/OfferSection.astro
+++ b/src/components/OfferSection.astro
@@ -63,8 +63,7 @@
 							href="/aanvragen"
 							class="w-full bg-ink text-acid py-4 font-bold uppercase tracking-tight hover:bg-canvas hover:text-ink transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 						>
-							<span>Plan Je Gesprek</span>
-							<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
+							<span>Start Jouw Project</span>
 						</a>
 					</div>
 				</div>
@@ -141,8 +140,7 @@
 							href="/aanvragen"
 							class="w-full bg-acid text-ink py-4 font-bold uppercase tracking-tight hover:bg-canvas hover:text-ink transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 						>
-							<span>Plan Je Gesprek</span>
-							<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
+							<span>Start Jouw Project</span>
 						</a>
 					</div>
 
@@ -265,7 +263,7 @@
 						href="/aanvragen"
 						class="mt-6 w-full border-2 border-canvas text-canvas py-4 font-bold uppercase tracking-tight hover:bg-canvas hover:text-ink transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 					>
-						<span>Bespreek De Mogelijkheden</span>
+						<span>Plan Een Kennismaking</span>
 						<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 					</a>
 				</div>

--- a/src/components/TypingRotator.tsx
+++ b/src/components/TypingRotator.tsx
@@ -1,0 +1,90 @@
+import { useState, useEffect, useCallback } from "react";
+
+interface TypingRotatorProps {
+	prefix: string;
+	words: string[];
+	typingSpeed?: number;
+	deletingSpeed?: number;
+	pauseDuration?: number;
+	className?: string;
+}
+
+export function TypingRotator({
+	prefix,
+	words,
+	typingSpeed = 100,
+	deletingSpeed = 50,
+	pauseDuration = 2000,
+	className = "",
+}: TypingRotatorProps) {
+	// Start with first word fully typed to avoid flash of empty content
+	const [currentWordIndex, setCurrentWordIndex] = useState(0);
+	const [displayedText, setDisplayedText] = useState(words[0] || "");
+	const [isDeleting, setIsDeleting] = useState(false);
+	const [isPaused, setIsPaused] = useState(true); // Start paused since word is already shown
+	const [isFirstRun, setIsFirstRun] = useState(true);
+
+	const currentWord = words[currentWordIndex];
+
+	// Hide the server-rendered placeholder when component mounts
+	useEffect(() => {
+		const placeholder = document.getElementById("typing-placeholder");
+		if (placeholder) placeholder.style.display = "none";
+	}, []);
+
+	// Initial pause before starting to delete the first word
+	useEffect(() => {
+		if (isFirstRun) {
+			const timer = setTimeout(() => {
+				setIsPaused(false);
+				setIsDeleting(true);
+				setIsFirstRun(false);
+			}, pauseDuration);
+			return () => clearTimeout(timer);
+		}
+	}, [isFirstRun, pauseDuration]);
+
+	const tick = useCallback(() => {
+		if (isPaused) return;
+
+		if (!isDeleting) {
+			// Typing
+			if (displayedText.length < currentWord.length) {
+				setDisplayedText(currentWord.slice(0, displayedText.length + 1));
+			} else {
+				// Finished typing, pause before deleting
+				setIsPaused(true);
+				setTimeout(() => {
+					setIsPaused(false);
+					setIsDeleting(true);
+				}, pauseDuration);
+			}
+		} else {
+			// Deleting
+			if (displayedText.length > 0) {
+				setDisplayedText(displayedText.slice(0, -1));
+			} else {
+				// Finished deleting, move to next word
+				setIsDeleting(false);
+				setCurrentWordIndex((prev) => (prev + 1) % words.length);
+			}
+		}
+	}, [currentWord, displayedText, isDeleting, isPaused, pauseDuration, words.length]);
+
+	useEffect(() => {
+		const speed = isDeleting ? deletingSpeed : typingSpeed;
+		const timer = setTimeout(tick, speed);
+		return () => clearTimeout(timer);
+	}, [tick, isDeleting, typingSpeed, deletingSpeed]);
+
+	return (
+		<span className={className}>
+			{prefix}
+			<span className="text-ink">{displayedText}</span>
+			<span
+				className="inline-block w-[2px] h-[1.1em] bg-ink ml-0.5 -mb-[0.15em]"
+				style={{ animation: "blink 1s step-end infinite" }}
+			/>
+		</span>
+	);
+}

--- a/src/pages/aanvragen.astro
+++ b/src/pages/aanvragen.astro
@@ -4,8 +4,8 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 ---
 
 <Layout
-	title="Gratis Adviesgesprek | Website €595 | KNAP GEMAAKT."
-	description="Plan een vrijblijvend gesprek en start met je nieuwe website. ✓ Binnen 7 dagen live ✓ €595 vast ✓ Geen verplichtingen. Wij bellen jou!"
+	title="Plan Een Kennismaking | Website €595 | KNAP GEMAAKT."
+	description="Plan een vrijblijvende kennismaking en start met je nieuwe website. ✓ Binnen 7 dagen live ✓ €595 vast ✓ Geen verplichtingen. Wij bellen jou!"
 >
     <main class="min-h-screen bg-canvas pt-32 pb-24 px-4 md:px-8 bg-grid-light relative overflow-hidden">
         <div class="max-w-4xl mx-auto">
@@ -276,7 +276,7 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
                         id="submit-btn"
                         class="w-full md:w-auto px-12 py-5 bg-acid text-ink font-bold uppercase tracking-tight text-xl hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                        <span id="btn-text">Plan Je Gesprek</span>
+                        <span id="btn-text">Plan Een Kennismaking</span>
                         <span id="btn-arrow" class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
                         <span id="btn-loading" class="hidden">
                             <svg

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -150,13 +150,13 @@ const breadcrumbs = [
 					</h2>
 					<p class="text-ink/60 mb-6 max-w-lg mx-auto">
 						Wil je weten wat wij voor jouw bedrijf kunnen betekenen?
-						Plan een gratis gesprek en we bespreken de mogelijkheden.
+						Plan een kennismaking en we bespreken de mogelijkheden.
 					</p>
 					<a
 						href="/aanvragen"
 						class="bg-acid text-ink px-8 py-4 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 					>
-						<span>Plan Gratis Gesprek</span>
+						<span>Plan Een Kennismaking</span>
 						<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 					</a>
 				</div>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -108,13 +108,13 @@ const breadcrumbs = [
 				</h2>
 				<p class="text-xl text-ink/60 max-w-2xl mx-auto mb-8">
 					Na al dat lezen ben je misschien wel klaar om de stap te zetten.
-					Plan een gratis gesprek en ontdek wat wij voor jouw bedrijf kunnen betekenen.
+					Plan een kennismaking en ontdek wat wij voor jouw bedrijf kunnen betekenen.
 				</p>
 				<a
 					href="/aanvragen"
 					class="bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 				>
-					<span>Plan Je Gratis Gesprek</span>
+					<span>Plan Een Kennismaking</span>
 					<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 				</a>
 			</div>

--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -130,13 +130,13 @@ const breadcrumbs = [
 				</h2>
 				<p class="text-xl text-ink/60 max-w-2xl mx-auto mb-8">
 					Na al dat lezen ben je misschien wel klaar om de stap te zetten.
-					Plan een gratis gesprek en ontdek wat wij voor jouw bedrijf kunnen betekenen.
+					Plan een kennismaking en ontdek wat wij voor jouw bedrijf kunnen betekenen.
 				</p>
 				<a
 					href="/aanvragen"
 					class="bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 				>
-					<span>Plan Je Gratis Gesprek</span>
+					<span>Plan Een Kennismaking</span>
 					<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 				</a>
 			</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,7 @@ import ProcessSection from "../components/ProcessSection.astro";
 import Footer from "../components/Footer.astro";
 import TextRevealCSS from "../components/TextRevealCSS.astro";
 import LocalBusinessSchema from "../components/seo/LocalBusinessSchema.astro";
+import { TypingRotator } from "../components/TypingRotator";
 import { getAllCities } from "../data/cities";
 
 const cities = getAllCities();
@@ -29,11 +30,6 @@ const cities = getAllCities();
 			<div class="absolute top-1/4 -right-1/4 w-[600px] h-[600px] bg-acid/5 rounded-full blur-[120px] pointer-events-none"></div>
 
 			<div class="max-w-6xl xl:max-w-7xl mx-auto w-full relative z-10">
-				<!-- Branding -->
-				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-8 md:mb-12">
-					[ KNAP GEMAAKT. Webdesign Nederland ]
-				</div>
-
 				<!-- H1 Headline -->
 				<h1 class="mb-6 md:mb-8">
 					<TextRevealCSS
@@ -48,10 +44,18 @@ const cities = getAllCities();
 					/>
 				</h1>
 
-				<!-- Subheadline -->
+				<!-- Subheadline with typing animation -->
 				<p class="text-lg md:text-xl lg:text-2xl text-ink/70 max-w-2xl mb-10 md:mb-12 leading-relaxed">
-					Professionele websites voor ondernemers in heel Nederland.
-					Vaste prijs, snelle levering, geen gedoe.
+					{/* Server-rendered placeholder for SEO & CLS prevention */}
+					<span id="typing-placeholder">Professionele websites voor ondernemers.</span>
+					<TypingRotator
+						client:load
+						prefix="Professionele websites voor "
+						words={["ondernemers", "schilders", "personal trainers", "kappers", "coaches", "gyms", "aanpakkers"]}
+						typingSpeed={80}
+						deletingSpeed={40}
+						pauseDuration={2500}
+					/>
 				</p>
 
 				<!-- CTA -->
@@ -59,7 +63,7 @@ const cities = getAllCities();
 					href="/aanvragen"
 					class="w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group mb-12 md:mb-16"
 				>
-					<span>Plan Je Gratis Gesprek</span>
+					<span>Plan Een Kennismaking</span>
 					<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 				</a>
 
@@ -111,7 +115,7 @@ const cities = getAllCities();
 						</p>
 						<p>
 							En ja, we schrijven ook je teksten. Want laten we eerlijk zijn: jij bent goed in je vak,
-							niet in het staren naar een leeg Word-document om 23:00. Wij regelen het. Jij ondernemt.
+							niet in het staren naar een leeg Word-document om 23:00. Wij regelen het. Jij onderneemt.
 						</p>
 					</div>
 				</div>
@@ -294,7 +298,7 @@ const cities = getAllCities();
 						href="/aanvragen"
 						class="bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 					>
-						<span>Plan Je Gesprek</span>
+						<span>Plan Een Kennismaking</span>
 						<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 					</a>
 				</div>

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -194,7 +194,7 @@ const breadcrumbs = [
                             href="/aanvragen"
                             class="w-full bg-ink text-acid py-4 font-bold uppercase tracking-tight hover:bg-canvas hover:text-ink transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
                         >
-                            <span>Plan Je Gratis Gesprek</span>
+                            <span>Plan Een Kennismaking</span>
                             <span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
                         </a>
                     </div>

--- a/src/pages/project/[slug].astro
+++ b/src/pages/project/[slug].astro
@@ -81,7 +81,7 @@ const pageTitle = `${project.title} | Website ${project.industry} Voorbeeld`;
 								href="/aanvragen"
 								class="w-full sm:w-auto border-2 border-ink text-ink px-8 py-[18px] font-bold uppercase tracking-tight hover:bg-ink hover:text-canvas transition-colors duration-300 text-center"
 							>
-								Ook Zo'n Site?
+								Start Jouw Project
 							</a>
 						</div>
 					</div>
@@ -214,8 +214,7 @@ const pageTitle = `${project.title} | Website ${project.industry} Voorbeeld`;
 								href="/aanvragen"
 								class="w-full bg-ink text-acid py-4 font-bold uppercase tracking-tight hover:bg-canvas hover:text-ink transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 							>
-								<span>Ook Zo'n Website?</span>
-								<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
+								<span>Start Jouw Project</span>
 							</a>
 						</div>
 

--- a/src/pages/webdesign-[city].astro
+++ b/src/pages/webdesign-[city].astro
@@ -81,7 +81,7 @@ const breadcrumbs = [
                             href="/aanvragen"
                             class="w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
                         >
-                            <span>Plan Je Gratis Gesprek</span>
+                            <span>Plan Een Kennismaking</span>
                             <span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
                         </a>
                     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -64,6 +64,16 @@
   }
 }
 
+/* Typing cursor blink animation */
+@keyframes blink {
+  0%, 50% {
+    opacity: 1;
+  }
+  51%, 100% {
+    opacity: 0;
+  }
+}
+
 /* Reusable grid backgrounds */
 .bg-grid-light {
   background-image:


### PR DESCRIPTION
## Summary
- Add typing animation to hero subtitle (cycles through target audiences)
- Fix typo: "ondernemt" → "onderneemt"  
- Remove branding text from hero section
- Unify all CTAs across the site for consistent messaging
- Add blinking cursor animation for typing effect
- Replace "gratis gesprek" with "kennismaking" for more premium positioning

## Changes
- **New component**: `TypingRotator.tsx` - React component for typing animation
- **12 files updated** with unified CTA copy

## CTA System
| Type | Copy | Arrow |
|------|------|-------|
| Primary | Plan Een Kennismaking | ✓ |
| Secondary | Start Jouw Project | ✗ |

## Test plan
- [ ] Verify typing animation works on homepage hero
- [ ] Check cursor blinks correctly
- [ ] Confirm all CTAs use consistent copy

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)