### PR TITLE
feat: add animated underline hover effect to nav menu ✨

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -48,7 +48,7 @@ const isActive = (href: string) => {
                     <a
                         href={link.href}
                         class:list={[
-                            "font-mono text-sm uppercase tracking-widest transition-colors",
+                            "nav-link-hover font-mono text-sm uppercase tracking-widest transition-colors relative",
                             isActive(link.href) ? "text-electric" : "text-ink/60 hover:text-ink"
                         ]}
                         aria-current={isActive(link.href) ? "page" : undefined}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -74,6 +74,29 @@
   }
 }
 
+/* Animated underline for nav links */
+.nav-link-hover::after {
+  content: '';
+  position: absolute;
+  bottom: -4px;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: currentColor;
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.nav-link-hover:hover::after {
+  transform: scaleX(1);
+}
+
+/* Keep underline visible for active nav link */
+.nav-link-hover[aria-current="page"]::after {
+  transform: scaleX(1);
+}
+
 /* Reusable grid backgrounds */
 .bg-grid-light {
   background-image:


### PR DESCRIPTION
## Summary
Add a polished animated underline effect to desktop navigation links for better UX feedback.

## Changes
- Nav links now have a sliding underline that expands from center on hover
- Active page link keeps underline visible
- Uses GPU-accelerated `transform: scaleX()` for smooth 60fps animation

## Technical Details
- `::after` pseudo-element for the underline
- `transform-origin: center` for balanced expansion
- `cubic-bezier(0.4, 0, 0.2, 1)` easing (Material Design standard)
- `currentColor` adapts to text color (ink or electric for active)

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)