### PR TITLE
Add contact page with alternative contact methods

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -36,6 +36,7 @@ const cities = getAllCities();
 		<div class="pt-8 border-t border-canvas/10">
 			<!-- Legal Links -->
 			<div class="flex flex-wrap justify-center md:justify-start gap-x-6 gap-y-2 font-mono text-xs text-canvas/50 uppercase tracking-widest mb-6">
+				<a href="/contact" class="hover:text-acid transition-colors">Contact</a>
 				<a href="/algemene-voorwaarden" class="hover:text-acid transition-colors">Voorwaarden</a>
 				<a href="/privacy" class="hover:text-acid transition-colors">Privacy</a>
 				<a href="/sitemap" class="hover:text-acid transition-colors">Sitemap</a>

--- a/src/pages/aanvragen.astro
+++ b/src/pages/aanvragen.astro
@@ -11,10 +11,18 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
         <div class="max-w-4xl mx-auto">
             <!-- Header -->
             <div class="mb-16" id="page-header">
-                <TextRevealCSS
-                    text="Start Je Aanvraag."
-                    class="text-5xl md:text-8xl font-black uppercase tracking-tighter leading-none mb-6"
-                />
+                <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4 mb-6">
+                    <TextRevealCSS
+                        text="Start Je Aanvraag."
+                        class="text-5xl md:text-8xl font-black uppercase tracking-tighter leading-none"
+                    />
+                    <a
+                        href="/contact"
+                        class="text-sm font-mono text-ink/40 hover:text-electric transition-colors whitespace-nowrap self-start md:self-auto md:mt-4"
+                    >
+                        Liever direct contact? &rarr;
+                    </a>
+                </div>
                 <p
                     class="text-xl md:text-2xl text-ink/60 font-medium max-w-4xl leading-relaxed"
                 >

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,112 @@
+---
+export const prerender = true;
+
+import Layout from "../layouts/Layout.astro";
+import Footer from "../components/Footer.astro";
+import TextRevealCSS from "../components/TextRevealCSS.astro";
+---
+
+<Layout
+	title="Contact | Neem Contact Op | KNAP GEMAAKT."
+	description="Heb je een vraag? Neem contact op via e-mail. We reageren meestal binnen 24 uur. Of plan direct een vrijblijvende kennismaking."
+>
+	<main class="min-h-screen bg-canvas pt-32 pb-24 px-4 md:px-8 bg-grid-light relative overflow-hidden">
+		<div class="max-w-4xl mx-auto">
+			<!-- Header -->
+			<div class="mb-16">
+				<TextRevealCSS
+					text="Contact."
+					class="text-5xl md:text-8xl font-black uppercase tracking-tighter leading-none mb-6"
+				/>
+				<p class="text-xl md:text-2xl text-ink/60 font-medium max-w-2xl leading-relaxed">
+					Heb je een vraag voordat je een afspraak inplant?<br />
+					Stuur ons een bericht.
+				</p>
+			</div>
+
+			<!-- Contact Options -->
+			<div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-16">
+				<!-- Email Card -->
+				<a
+					href="mailto:info@knapgemaakt.nl"
+					class="group p-8 border-2 border-ink/10 hover:border-ink transition-colors duration-300"
+				>
+					<div class="flex items-start gap-4">
+						<div class="w-12 h-12 bg-acid flex items-center justify-center flex-shrink-0">
+							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square" stroke-linejoin="miter">
+								<rect width="20" height="16" x="2" y="4" rx="2"/>
+								<path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
+							</svg>
+						</div>
+						<div class="flex-1">
+							<h2 class="text-xl font-bold uppercase tracking-tight mb-2 group-hover:text-electric transition-colors">
+								E-mail
+							</h2>
+							<p class="text-ink/60 font-mono text-sm mb-4">
+								info@knapgemaakt.nl
+							</p>
+							<p class="text-ink/40 text-sm">
+								We reageren meestal binnen 24 uur
+							</p>
+						</div>
+						<span class="text-ink/20 group-hover:text-ink group-hover:translate-x-1 transition-all duration-300 text-xl">
+							&rarr;
+						</span>
+					</div>
+				</a>
+
+				<!-- Location Card -->
+				<div class="p-8 border-2 border-ink/10 bg-ink/[0.02]">
+					<div class="flex items-start gap-4">
+						<div class="w-12 h-12 bg-ink/10 flex items-center justify-center flex-shrink-0">
+							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square" stroke-linejoin="miter">
+								<path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/>
+								<circle cx="12" cy="10" r="3"/>
+							</svg>
+						</div>
+						<div>
+							<h2 class="text-xl font-bold uppercase tracking-tight mb-2">
+								Locatie
+							</h2>
+							<p class="text-ink/60 font-mono text-sm mb-4">
+								Buren, Gelderland
+							</p>
+							<p class="text-ink/40 text-sm">
+								Remote-first — we werken vanuit heel Nederland
+							</p>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<!-- Business Info -->
+			<div class="border-t border-ink/10 pt-8 mb-16">
+				<div class="flex flex-wrap gap-x-8 gap-y-2 font-mono text-xs text-ink/40 uppercase tracking-widest">
+					<span>KvK: 73652377</span>
+					<span>BTW: NL002383577B12</span>
+				</div>
+			</div>
+
+			<!-- CTA Section -->
+			<div class="p-8 md:p-12 bg-ink text-canvas relative overflow-hidden">
+				<div class="absolute inset-0 bg-grid-dark opacity-50"></div>
+				<div class="relative z-10">
+					<h2 class="text-2xl md:text-4xl font-black uppercase tracking-tighter mb-4">
+						Klaar om te starten?
+					</h2>
+					<p class="text-canvas/60 text-lg mb-8 max-w-xl">
+						Plan een vrijblijvende kennismaking en ontdek hoe wij jouw website binnen 7 dagen kunnen bouwen.
+					</p>
+					<a
+						href="/aanvragen"
+						class="inline-flex items-center justify-center gap-3 px-8 py-[18px] bg-acid text-ink font-bold uppercase tracking-tight hover:bg-canvas hover:text-ink transition-colors duration-300 group"
+					>
+						<span>Plan Een Kennismaking</span>
+						<span class="text-xl leading-none transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
+					</a>
+				</div>
+			</div>
+		</div>
+	</main>
+	<Footer />
+</Layout>


### PR DESCRIPTION
## Summary
- Create `/contact` page with email and location info for visitors who prefer direct contact
- Add subtle "Liever direct contact?" link to `/aanvragen` page header (top-right)
- Add Contact link to footer navigation for discoverability

## Design Decisions
- **Email-only for now** — no phone/WhatsApp displayed (can be added later)
- **No business hours** — remote-first approach
- **Location shows "Buren, Gelderland"** — legitimacy signal without full address
- **"Remote-first" messaging** — explains lack of physical office

## Screenshots
The contact page includes:
- Email card with mailto link
- Location info (non-clickable)
- Business identifiers (KvK, BTW)
- CTA back to /aanvragen for those ready to book

## Test plan
- [ ] Visit `/contact` and verify email link works
- [ ] Visit `/aanvragen` and verify "Liever direct contact?" link appears top-right
- [ ] Check footer on any page for Contact link
- [ ] Verify mobile responsiveness on both pages

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)