### PR TITLE
fix: improve mobile menu performance with visibility toggle 🐛

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -86,7 +86,7 @@ const isActive = (href: string) => {
 
 <!-- Fullscreen Mobile Menu Overlay -->
 <nav
-    class="mobile-menu-overlay fixed inset-0 z-[55] flex flex-col md:hidden pointer-events-none"
+    class="mobile-menu-overlay fixed inset-0 z-[55] flex flex-col md:hidden pointer-events-none invisible"
     id="mobile-nav"
     aria-label="Mobiele navigatie"
     aria-hidden="true"
@@ -94,9 +94,6 @@ const isActive = (href: string) => {
     <!-- Animated background panels -->
     <div class="menu-bg-panel menu-bg-panel-1 absolute inset-0 bg-ink origin-top"></div>
     <div class="menu-bg-panel menu-bg-panel-2 absolute inset-0 bg-ink/95 origin-top"></div>
-
-    <!-- Decorative grid background -->
-    <div class="menu-grid absolute inset-0 bg-grid-dark opacity-0 pointer-events-none"></div>
 
     <!-- Menu Content -->
     <div class="menu-content relative flex-1 flex flex-col justify-center items-center px-8 pt-20 opacity-0">
@@ -168,12 +165,6 @@ const isActive = (href: string) => {
         transform: scaleY(1);
     }
 
-    /* Grid fade in */
-    .mobile-menu-overlay.is-open .menu-grid {
-        opacity: 0.5;
-        transition: opacity 0.8s ease 0.4s;
-    }
-
     /* Content fade in */
     .menu-content {
         transition: opacity 0.4s ease;
@@ -235,9 +226,10 @@ const isActive = (href: string) => {
         opacity: 1;
     }
 
-    /* Enable pointer events when open */
+    /* Enable pointer events and visibility when open */
     .mobile-menu-overlay.is-open {
         pointer-events: auto;
+        visibility: visible;
     }
 
     /* ================================


### PR DESCRIPTION
## Summary
- Add `visibility: hidden` to mobile menu overlay when closed to eliminate GPU compositing cost
- Add `visibility: visible` when menu is open (`.is-open` state)
- Remove expensive `bg-grid-dark` decorative element from fullscreen overlay
- Clean up unused `.menu-grid` CSS

## Root Cause
The mobile menu overlay was always rendered in the DOM with `opacity: 0` and `pointer-events: none`, but iOS Safari still paid the GPU compositing cost for the fullscreen element and its complex animations. The `bg-grid-dark` repeating gradient pattern added additional rendering overhead.

## Solution
Using `visibility: hidden` tells the browser to skip layout and paint entirely when the menu is closed, while still allowing smooth animations when opening (visibility transitions at animation boundaries).

## Test plan
- [ ] Test homepage load on iPhone - should be snappy
- [ ] Test burger menu open/close - should animate smoothly
- [ ] Verify menu still works correctly on desktop

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)