### PR TITLE
feat(cookies): add GDPR-compliant cookie consent system ✨

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# =============================================================================
+# TRACKING & ANALYTICS CONFIGURATION
+# =============================================================================
+# Copy this file to .env and fill in your values
+# Scripts are BLOCKED by default until user consents (GDPR compliant)
+
+# Google Analytics 4
+# Get from: https://analytics.google.com → Admin → Data Streams → Measurement ID
+PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+
+# Meta (Facebook) Pixel
+# Get from: https://business.facebook.com → Events Manager → Data Sources
+PUBLIC_META_PIXEL_ID=1234567890123456
+
+# =============================================================================
+# FUTURE SERVICES (add when needed)
+# =============================================================================
+
+# LinkedIn Insight Tag
+# PUBLIC_LINKEDIN_PARTNER_ID=123456
+
+# Leadinfo (B2B IP tracking)
+# PUBLIC_LEADINFO_ID=xxxxxxxx
+
+# Microsoft Clarity
+# PUBLIC_CLARITY_ID=xxxxxxxxxx
+
+# Hotjar
+# PUBLIC_HOTJAR_ID=1234567

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -1,0 +1,430 @@
+import { useState, useEffect, useCallback } from 'react';
+
+// =============================================================================
+// CONFIGURATION - Edit these when adding new services
+// =============================================================================
+
+const CONSENT_VERSION = '1.0';
+const STORAGE_KEY = 'cookie_consent';
+const CONSENT_EXPIRY_DAYS = 365;
+
+interface ConsentCategories {
+  necessary: boolean;
+  analytics: boolean;
+  marketing: boolean;
+}
+
+interface ConsentData {
+  version: string;
+  timestamp: number;
+  expiresAt: number;
+  categories: ConsentCategories;
+  consentId: string;
+}
+
+// =============================================================================
+// CONSENT LOGIC
+// =============================================================================
+
+function generateConsentId(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+function getStoredConsent(): ConsentData | null {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return null;
+
+    const data: ConsentData = JSON.parse(stored);
+
+    // Check version and expiry
+    if (data.version !== CONSENT_VERSION || data.expiresAt < Date.now()) {
+      return null;
+    }
+
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+function saveConsent(categories: ConsentCategories): void {
+  const data: ConsentData = {
+    version: CONSENT_VERSION,
+    timestamp: Date.now(),
+    expiresAt: Date.now() + CONSENT_EXPIRY_DAYS * 24 * 60 * 60 * 1000,
+    categories,
+    consentId: generateConsentId(),
+  };
+
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+
+  // Clear the "banner showing" flag since user made a choice
+  sessionStorage.removeItem('cookie_banner_showing');
+
+  // Also set a simple cookie for potential server-side detection
+  document.cookie = `consent_given=1; path=/; max-age=${CONSENT_EXPIRY_DAYS * 24 * 60 * 60}; SameSite=Lax`;
+}
+
+function updateGoogleConsentMode(categories: ConsentCategories): void {
+  if (typeof window !== 'undefined' && typeof (window as any).gtag === 'function') {
+    (window as any).gtag('consent', 'update', {
+      'analytics_storage': categories.analytics ? 'granted' : 'denied',
+      'ad_storage': categories.marketing ? 'granted' : 'denied',
+      'ad_user_data': categories.marketing ? 'granted' : 'denied',
+      'ad_personalization': categories.marketing ? 'granted' : 'denied',
+    });
+  }
+}
+
+function updateLeadinfoConsent(analyticsConsent: boolean): void {
+  // Leadinfo runs cookieless by default (Legitimate Interest)
+  // When analytics consent is granted, enable full cookie tracking
+  if (typeof window !== 'undefined' && typeof (window as any).leadinfo === 'function') {
+    (window as any).leadinfo('consent', analyticsConsent);
+  }
+}
+
+function enableBlockedScripts(category: 'analytics' | 'marketing'): void {
+  document.querySelectorAll(`script[type="text/plain"][data-consent="${category}"]`)
+    .forEach((script) => {
+      const newScript = document.createElement('script');
+      const src = script.getAttribute('data-src');
+
+      if (src) {
+        newScript.src = src;
+        newScript.async = true;
+      } else {
+        newScript.textContent = script.textContent;
+      }
+
+      script.parentNode?.replaceChild(newScript, script);
+    });
+}
+
+// =============================================================================
+// COOKIE CONSENT COMPONENT
+// =============================================================================
+
+// Session flag to persist banner state across View Transitions
+const BANNER_SHOWING_KEY = 'cookie_banner_showing';
+
+export function CookieConsent() {
+  const [showBanner, setShowBanner] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
+  const [categories, setCategories] = useState<ConsentCategories>({
+    necessary: true,
+    analytics: false,
+    marketing: false,
+  });
+
+  // Initialize on mount and handle View Transitions
+  useEffect(() => {
+    const checkAndShowBanner = () => {
+      const stored = getStoredConsent();
+
+      if (stored) {
+        // User already made a choice - apply it
+        setCategories(stored.categories);
+        applyConsent(stored.categories);
+        setShowBanner(false);
+        sessionStorage.removeItem(BANNER_SHOWING_KEY);
+      } else {
+        // No consent stored - check if banner was already showing
+        const wasShowing = sessionStorage.getItem(BANNER_SHOWING_KEY);
+        if (wasShowing) {
+          // Banner was showing before navigation - show immediately
+          setShowBanner(true);
+        } else {
+          // First visit - show after brief delay
+          const timer = setTimeout(() => {
+            setShowBanner(true);
+            sessionStorage.setItem(BANNER_SHOWING_KEY, 'true');
+          }, 1000);
+          return () => clearTimeout(timer);
+        }
+      }
+    };
+
+    checkAndShowBanner();
+
+    // Re-check after View Transitions (Astro navigation)
+    const handleSwap = () => {
+      // Small delay to let the new page settle
+      setTimeout(checkAndShowBanner, 100);
+    };
+
+    document.addEventListener('astro:after-swap', handleSwap);
+    return () => document.removeEventListener('astro:after-swap', handleSwap);
+  }, []);
+
+  // Listen for footer link clicks (works across View Transitions)
+  useEffect(() => {
+    const handler = () => {
+      // Check if user already has consent stored
+      const hasExistingConsent = getStoredConsent() !== null;
+
+      setShowSettings(true);
+
+      if (hasExistingConsent) {
+        // User already made a choice - only show settings modal (not banner afterward)
+        setShowBanner(false);
+      } else {
+        // No consent yet - show banner too (in case they close settings without saving)
+        setShowBanner(true);
+        sessionStorage.setItem(BANNER_SHOWING_KEY, 'true');
+      }
+    };
+
+    window.addEventListener('openCookieSettings', handler);
+    document.addEventListener('astro:after-swap', () => {
+      // Re-attach listener after View Transition
+      window.addEventListener('openCookieSettings', handler);
+    });
+
+    return () => window.removeEventListener('openCookieSettings', handler);
+  }, []);
+
+  const applyConsent = useCallback((cats: ConsentCategories) => {
+    // Update Google Consent Mode
+    updateGoogleConsentMode(cats);
+
+    // Update Leadinfo consent (upgrades from cookieless to full tracking)
+    updateLeadinfoConsent(cats.analytics);
+
+    // Enable blocked scripts based on consent
+    if (cats.analytics) enableBlockedScripts('analytics');
+    if (cats.marketing) enableBlockedScripts('marketing');
+  }, []);
+
+  const handleAcceptAll = useCallback(() => {
+    const newCategories: ConsentCategories = {
+      necessary: true,
+      analytics: true,
+      marketing: true,
+    };
+
+    setCategories(newCategories);
+    saveConsent(newCategories);
+    applyConsent(newCategories);
+    setShowBanner(false);
+    setShowSettings(false);
+  }, [applyConsent]);
+
+  const handleRejectAll = useCallback(() => {
+    const newCategories: ConsentCategories = {
+      necessary: true,
+      analytics: false,
+      marketing: false,
+    };
+
+    setCategories(newCategories);
+    saveConsent(newCategories);
+    applyConsent(newCategories);
+    setShowBanner(false);
+    setShowSettings(false);
+  }, [applyConsent]);
+
+  const handleSavePreferences = useCallback(() => {
+    saveConsent(categories);
+    applyConsent(categories);
+    setShowBanner(false);
+    setShowSettings(false);
+  }, [categories, applyConsent]);
+
+  const handleToggleCategory = useCallback((category: 'analytics' | 'marketing') => {
+    setCategories((prev) => ({
+      ...prev,
+      [category]: !prev[category],
+    }));
+  }, []);
+
+  // Nothing to show
+  if (!showBanner && !showSettings) return null;
+
+  // ==========================================================================
+  // SETTINGS MODAL - Full-screen overlay with backdrop (blocks page interaction)
+  // Can show independently (when opened from footer after user already made a choice)
+  // ==========================================================================
+  if (showSettings) {
+    return (
+      <div
+        className="fixed inset-0 z-[9999] flex items-center justify-center p-4"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cookie-title"
+      >
+        {/* Backdrop - closes modal on click */}
+        <div
+          className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+          onClick={() => setShowSettings(false)}
+        />
+
+        {/* Settings Panel */}
+        <div className="relative w-full max-w-2xl bg-ink text-canvas shadow-2xl rounded-xl">
+          <div className="p-6 md:p-8">
+            <div className="flex items-start justify-between mb-6">
+              <h2 id="cookie-title" className="text-xl md:text-2xl font-bold">
+                Cookie-instellingen
+              </h2>
+              <button
+                onClick={() => setShowSettings(false)}
+                className="p-2 hover:bg-canvas/10 rounded-lg transition-colors"
+                aria-label="Sluiten"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            <p className="text-canvas/70 text-sm mb-6">
+              Wij gebruiken cookies om je ervaring te verbeteren. Je kunt per categorie aangeven welke cookies je accepteert.
+            </p>
+
+            {/* Category Toggles */}
+            <div className="space-y-4 mb-8">
+              {/* Necessary - Always on */}
+              <div className="flex items-center justify-between p-4 bg-canvas/5 rounded-lg">
+                <div>
+                  <h3 className="font-semibold">Noodzakelijk</h3>
+                  <p className="text-sm text-canvas/60">Essentieel voor de werking van de website</p>
+                </div>
+                <div className="px-3 py-1 bg-acid/20 text-acid text-xs font-mono rounded whitespace-nowrap shrink-0">
+                  Altijd aan
+                </div>
+              </div>
+
+              {/* Analytics */}
+              <div className="flex items-center justify-between p-4 bg-canvas/5 rounded-lg hover:bg-canvas/10 transition-colors">
+                <div>
+                  <h3 className="font-semibold">Analytisch</h3>
+                  <p className="text-sm text-canvas/60">Helpt ons de website te verbeteren (Google Analytics, Leadinfo)</p>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={categories.analytics}
+                  onClick={() => handleToggleCategory('analytics')}
+                  className={`
+                    relative shrink-0 w-12 h-7 rounded-full transition-colors cursor-pointer
+                    ${categories.analytics ? 'bg-acid' : 'bg-canvas/20'}
+                  `}
+                >
+                  <span
+                    className={`
+                      absolute top-1 left-1 w-5 h-5 bg-white rounded-full shadow-md transition-transform duration-200
+                      ${categories.analytics ? 'translate-x-5' : 'translate-x-0'}
+                    `}
+                  />
+                </button>
+              </div>
+
+              {/* Marketing */}
+              <div className="flex items-center justify-between p-4 bg-canvas/5 rounded-lg hover:bg-canvas/10 transition-colors">
+                <div>
+                  <h3 className="font-semibold">Marketing</h3>
+                  <p className="text-sm text-canvas/60">Voor gepersonaliseerde advertenties (Meta, LinkedIn)</p>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={categories.marketing}
+                  onClick={() => handleToggleCategory('marketing')}
+                  className={`
+                    relative shrink-0 w-12 h-7 rounded-full transition-colors cursor-pointer
+                    ${categories.marketing ? 'bg-acid' : 'bg-canvas/20'}
+                  `}
+                >
+                  <span
+                    className={`
+                      absolute top-1 left-1 w-5 h-5 bg-white rounded-full shadow-md transition-transform duration-200
+                      ${categories.marketing ? 'translate-x-5' : 'translate-x-0'}
+                    `}
+                  />
+                </button>
+              </div>
+            </div>
+
+            {/* Action Buttons - Equal prominence */}
+            <div className="flex flex-col sm:flex-row gap-3">
+              <button
+                onClick={handleSavePreferences}
+                className="flex-1 px-6 py-3 bg-canvas text-ink font-semibold rounded-lg hover:bg-canvas/90 transition-colors"
+              >
+                Voorkeuren opslaan
+              </button>
+              <button
+                onClick={handleAcceptAll}
+                className="flex-1 px-6 py-3 bg-canvas text-ink font-semibold rounded-lg hover:bg-canvas/90 transition-colors"
+              >
+                Alles accepteren
+              </button>
+            </div>
+
+            <div className="mt-4 text-center">
+              <a href="/privacy#cookies" className="text-sm text-canvas/50 hover:text-acid transition-colors underline">
+                Bekijk ons cookiebeleid
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ==========================================================================
+  // SIMPLE BANNER - Fixed at bottom, NO overlay (allows clicking rest of page)
+  // ==========================================================================
+  return (
+    <div
+      className="fixed bottom-0 left-0 right-0 z-[9999] bg-ink text-canvas shadow-2xl"
+      role="dialog"
+      aria-labelledby="cookie-title"
+    >
+      <div className="p-4 md:p-6">
+        <div className="max-w-6xl mx-auto flex flex-col md:flex-row md:items-center gap-4 md:gap-6">
+          <div className="flex-1">
+            <h2 id="cookie-title" className="font-bold text-lg mb-1">
+              Wij gebruiken cookies
+            </h2>
+            <p className="text-canvas/70 text-sm">
+              Om je de beste ervaring te bieden gebruiken wij cookies voor analyse en marketing.{' '}
+              <a href="/privacy#cookies" className="text-acid hover:underline">Meer info</a>
+            </p>
+          </div>
+
+          {/* Buttons - Equal prominence as required by Dutch DPA */}
+          <div className="flex flex-col sm:flex-row gap-3">
+            <button
+              onClick={handleAcceptAll}
+              className="px-6 py-3 bg-canvas text-ink font-semibold rounded-lg hover:bg-canvas/90 transition-colors min-w-[140px]"
+            >
+              Accepteren
+            </button>
+            <button
+              onClick={handleRejectAll}
+              className="px-6 py-3 bg-canvas text-ink font-semibold rounded-lg hover:bg-canvas/90 transition-colors min-w-[140px]"
+            >
+              Weigeren
+            </button>
+            <button
+              onClick={() => setShowSettings(true)}
+              className="px-6 py-3 border border-canvas/30 text-canvas font-semibold rounded-lg hover:bg-canvas/10 transition-colors min-w-[140px]"
+            >
+              Aanpassen
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CookieConsent;

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -40,6 +40,17 @@ const cities = getAllCities();
 				<a href="/algemene-voorwaarden" class="hover:text-acid transition-colors">Voorwaarden</a>
 				<a href="/privacy" class="hover:text-acid transition-colors">Privacy</a>
 				<a href="/sitemap" class="hover:text-acid transition-colors">Sitemap</a>
+				<button
+					type="button"
+					id="cookie-settings-trigger"
+					class="hover:text-acid transition-colors flex items-center gap-1.5 cursor-pointer"
+					aria-label="Open cookie-instellingen"
+				>
+					<svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
+						<path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/>
+					</svg>
+					Cookie-instellingen
+				</button>
 			</div>
 
 			<!-- Business Info + Copyright -->
@@ -57,3 +68,23 @@ const cities = getAllCities();
 		</div>
 	</div>
 </footer>
+
+<script>
+	// Connect footer button to CookieConsent component
+	// Works with Astro View Transitions
+	function attachCookieSettingsHandler() {
+		const btn = document.getElementById('cookie-settings-trigger');
+		if (btn && !btn.dataset.listenerAttached) {
+			btn.addEventListener('click', () => {
+				window.dispatchEvent(new CustomEvent('openCookieSettings'));
+			});
+			btn.dataset.listenerAttached = 'true';
+		}
+	}
+
+	// Attach on initial load
+	attachCookieSettingsHandler();
+
+	// Re-attach after View Transitions
+	document.addEventListener('astro:after-swap', attachCookieSettingsHandler);
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,6 +5,7 @@ import "../styles/global.css";
 import { ViewTransitions } from "astro:transitions";
 import { SmoothScroll } from "../components/SmoothScroll";
 import Header from "../components/Header.astro";
+import CookieConsent from "../components/CookieConsent";
 
 // Import font files for preloading - all critical weights
 import interTight400 from "@fontsource/inter-tight/files/inter-tight-latin-400-normal.woff2";
@@ -25,6 +26,13 @@ const {
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const ogImageURL = new URL(image, Astro.site);
+
+// =============================================================================
+// TRACKING IDs
+// =============================================================================
+const GA_MEASUREMENT_ID = 'G-BBR63CY7Q9';
+const META_PIXEL_ID = import.meta.env.PUBLIC_META_PIXEL_ID || '';
+const LEADINFO_ID = 'LI-6973D746ECCF2';
 ---
 
 <!doctype html>
@@ -33,6 +41,42 @@ const ogImageURL = new URL(image, Astro.site);
     <meta charset="UTF-8" />
     <meta name="description" content={description} />
     <meta name="viewport" content="width=device-width" />
+
+    <!-- =========================================================================
+         GOOGLE CONSENT MODE v2 - MUST be first script (before any Google tags)
+         Sets all consent to denied by default for GDPR compliance
+         ========================================================================= -->
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+
+      // Default: all denied for GDPR/AVG compliance
+      gtag('consent', 'default', {
+        'ad_storage': 'denied',
+        'ad_user_data': 'denied',
+        'ad_personalization': 'denied',
+        'analytics_storage': 'denied',
+        'functionality_storage': 'granted',
+        'personalization_storage': 'denied',
+        'security_storage': 'granted',
+        'wait_for_update': 500
+      });
+
+      // Privacy-preserving features
+      gtag("set", "ads_data_redaction", true);
+      gtag("set", "url_passthrough", true);
+    </script>
+
+    <!-- =========================================================================
+         LEADINFO - Loads immediately in cookieless mode (Legitimate Interest)
+         Upgrades to full tracking after analytics consent granted
+         ========================================================================= -->
+    <script is:inline define:vars={{ LEADINFO_ID }}>
+      (function(l,e,a,d,i,n,f,o){if(!l[i]){l.GlobalLeadinfoNamespace=l.GlobalLeadinfoNamespace||[];
+      l.GlobalLeadinfoNamespace.push(i);l[i]=function(){(l[i].q=l[i].q||[]).push(arguments)};l[i].t=l[i].t||n;
+      l[i].q=l[i].q||[];o=e.createElement(a);f=e.getElementsByTagName(a)[0];o.async=1;o.src=d;f.parentNode.insertBefore(o,f);}
+      }(window,document,'script','https://cdn.leadinfo.net/ping.js','leadinfo',LEADINFO_ID));
+    </script>
     <link rel="icon" type="image/svg+xml" href="/favicon_final.svg" />
     <!-- Preload all font weights - ensures they arrive within 100ms for font-display: optional -->
     <link rel="preload" href={interTight400} as="font" type="font/woff2" crossorigin />
@@ -98,6 +142,45 @@ const ogImageURL = new URL(image, Astro.site);
         }, { capture: true });
       }
     </script>
+
+    <!-- =========================================================================
+         TRACKING SCRIPTS - Blocked until consent granted
+         Uses type="text/plain" to prevent execution before consent
+         ========================================================================= -->
+
+    {/* Google Analytics 4 - Only loads after analytics consent */}
+    {GA_MEASUREMENT_ID && (
+      <>
+        <script
+          type="text/plain"
+          data-consent="analytics"
+          data-src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+        />
+        <script type="text/plain" data-consent="analytics" set:html={`
+          gtag('js', new Date());
+          gtag('config', '${GA_MEASUREMENT_ID}', {
+            anonymize_ip: true,
+            cookie_flags: 'SameSite=None;Secure'
+          });
+        `} />
+      </>
+    )}
+
+    {/* Meta Pixel - Only loads after marketing consent */}
+    {META_PIXEL_ID && (
+      <script type="text/plain" data-consent="marketing" set:html={`
+        !function(f,b,e,v,n,t,s)
+        {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+        n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+        if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+        n.queue=[];t=b.createElement(e);t.async=!0;
+        t.src=v;s=b.getElementsByTagName(e)[0];
+        s.parentNode.insertBefore(t,s)}(window, document,'script',
+        'https://connect.facebook.net/en_US/fbevents.js');
+        fbq('init', '${META_PIXEL_ID}');
+        fbq('track', 'PageView');
+      `} />
+    )}
   </head>
   <body
     class="bg-canvas text-ink antialiased overflow-x-hidden selection:bg-acid selection:text-black"
@@ -116,5 +199,8 @@ const ogImageURL = new URL(image, Astro.site);
         }
       });
     </script>
+
+    <!-- Cookie Consent Banner -->
+    <CookieConsent client:load />
   </body>
 </html>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -60,7 +60,7 @@ import Footer from "../components/Footer.astro";
                             >
                                 <li>KvK: 73652377</li>
                                 <li>BTW: NL002383577B12</li>
-                                <li>E-mail: legal@knapgemaakt.nl</li>
+                                <li>E-mail: <a href="mailto:legal@knapgemaakt.nl" class="text-ink underline decoration-acid decoration-2 underline-offset-4 hover:bg-acid hover:decoration-transparent transition-colors">legal@knapgemaakt.nl</a></li>
                             </ul>
                         </div>
                     </div>
@@ -173,6 +173,12 @@ import Footer from "../components/Footer.astro";
                                     Resend (verzenden van afspraakbevestigingen)
                                 </li>
                                 <li>Google Calendar (agenda-afspraken)</li>
+                                <li>
+                                    Google Analytics (websitestatistieken, na toestemming)
+                                </li>
+                                <li>
+                                    Leadinfo (B2B-bezoekersidentificatie)
+                                </li>
                                 <li>
                                     n8n (zelf gehoste workflow-automatisering)
                                 </li>
@@ -297,8 +303,9 @@ import Footer from "../components/Footer.astro";
                     </div>
                 </section>
 
-                <!-- 09. Opslag -->
+                <!-- 09. Cookies & Opslag -->
                 <section
+                    id="cookies"
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
@@ -310,17 +317,63 @@ import Footer from "../components/Footer.astro";
                         <h2
                             class="text-3xl md:text-5xl font-bold uppercase tracking-tight"
                         >
-                            Opslag
+                            Cookies
                         </h2>
                         <div
                             class="prose prose-lg md:prose-xl prose-invert max-w-none text-ink/80 leading-relaxed"
                         >
                             <p>
-                                Wij gebruiken geen analytics of tracking
-                                cookies. Voor het formulier kunnen we lokale
-                                opslag (localStorage) gebruiken om je invoer te
-                                bewaren op je eigen apparaat. Je kunt dit zelf
-                                wissen in je browser.
+                                Wij gebruiken cookies en vergelijkbare technologie&euml;n.
+                                Bij je eerste bezoek vragen wij via een cookiebanner om toestemming.
+                            </p>
+
+                            <p class="mt-4"><strong class="text-ink">Noodzakelijke cookies</strong> (altijd actief):</p>
+                            <p>Deze cookies zijn essentieel voor de werking van de website en kunnen niet worden uitgeschakeld.</p>
+                            <ul class="list-disc pl-5 space-y-1 mt-2">
+                                <li><code class="text-sm bg-ink/10 px-1 rounded">cookie_consent</code> &ndash; Onthoudt je cookiekeuze (1 jaar)</li>
+                                <li><code class="text-sm bg-ink/10 px-1 rounded">__cf_bm</code> &ndash; Cloudflare botbescherming (30 min)</li>
+                                <li>localStorage &ndash; Tijdelijk opslaan van formuliergegevens tijdens invullen (wordt gewist na verzenden)</li>
+                            </ul>
+
+                            <p class="mt-4"><strong class="text-ink">Analytische cookies</strong> (na toestemming):</p>
+                            <p>Helpen ons begrijpen hoe bezoekers de website gebruiken.</p>
+                            <ul class="list-disc pl-5 space-y-1 mt-2">
+                                <li><code class="text-sm bg-ink/10 px-1 rounded">_ga</code>, <code class="text-sm bg-ink/10 px-1 rounded">_ga_*</code> &ndash; Google Analytics (2 jaar)</li>
+                                <li><code class="text-sm bg-ink/10 px-1 rounded">_li_id</code>, <code class="text-sm bg-ink/10 px-1 rounded">_li_ses</code> &ndash; Leadinfo sessietracking (1 jaar / sessie)</li>
+                            </ul>
+
+                            <p class="mt-4"><strong class="text-ink">Marketingcookies</strong> (na toestemming):</p>
+                            <p>Worden gebruikt om advertenties relevanter te maken.</p>
+                            <ul class="list-disc pl-5 space-y-1 mt-2">
+                                <li><code class="text-sm bg-ink/10 px-1 rounded">_fbp</code> &ndash; Meta Pixel (3 maanden)</li>
+                            </ul>
+
+                            <p class="mt-4"><strong class="text-ink">B2B-identificatie (Leadinfo)</strong></p>
+                            <p>
+                                Wij gebruiken Leadinfo om zakelijke bezoekers te identificeren
+                                op basis van IP-adres. Dit verwerken wij op grond van ons
+                                gerechtvaardigd belang. Wij identificeren alleen bedrijven,
+                                geen individuele personen. Met toestemming worden aanvullende
+                                cookies geplaatst voor sessietracking. Je kunt bezwaar maken via:
+                                <a
+                                    href="https://www.leadinfo.com/en/opt-out"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="text-ink underline decoration-acid decoration-2 underline-offset-4 hover:bg-acid hover:decoration-transparent transition-colors"
+                                    >leadinfo.com/opt-out</a
+                                >.
+                            </p>
+
+                            <p class="mt-4"><strong class="text-ink">Cloudflare</strong></p>
+                            <p>
+                                Onze website wordt gehost via Cloudflare Pages. Cloudflare plaatst
+                                beveiligingscookies voor DDoS-bescherming en botdetectie. Deze cookies
+                                zijn strikt noodzakelijk en vereisen geen toestemming.
+                            </p>
+
+                            <p class="mt-4">
+                                Je kunt je cookievoorkeuren altijd wijzigen via de link
+                                &ldquo;Cookie-instellingen&rdquo; in de footer van onze website.
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Add GDPR/AVG-compliant cookie consent banner with equal Accept/Reject prominence
- Implement Google Consent Mode v2 with denied defaults
- Add Leadinfo hybrid approach (cookieless by default, cookies after consent)
- Block GA4 and Meta Pixel scripts until explicit consent
- Add footer link to re-open cookie settings (works with View Transitions)
- Update privacy policy with detailed cookie table and Cloudflare disclosure

## Test plan
- [ ] Verify cookie banner appears on first visit after 1 second delay
- [ ] Verify Accept/Reject buttons have equal visual prominence
- [ ] Verify scripts are blocked until consent (check Network tab)
- [ ] Verify Google Consent Mode updates on consent change
- [ ] Verify settings modal opens from footer link
- [ ] Verify banner persists across View Transitions navigation
- [ ] Verify mobile layout (toggles, "Altijd aan" badge)
- [ ] Verify privacy policy links go to #cookies section

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)