### PR TITLE
feat(analytics): add Microsoft Clarity for heatmaps & session recordings ✨

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,18 +12,20 @@ PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
 # Get from: https://business.facebook.com → Events Manager → Data Sources
 PUBLIC_META_PIXEL_ID=1234567890123456
 
+# Microsoft Clarity (heatmaps & session recordings)
+# Get from: https://clarity.microsoft.com → Settings → Project ID
+# PUBLIC_CLARITY_ID=xxxxxxxxxx
+
+# Leadinfo (B2B IP tracking)
+# Get from: https://app.leadinfo.com → Settings → Script
+# PUBLIC_LEADINFO_ID=LI-XXXXXXXXXXXX
+
 # =============================================================================
 # FUTURE SERVICES (add when needed)
 # =============================================================================
 
 # LinkedIn Insight Tag
 # PUBLIC_LINKEDIN_PARTNER_ID=123456
-
-# Leadinfo (B2B IP tracking)
-# PUBLIC_LEADINFO_ID=xxxxxxxx
-
-# Microsoft Clarity
-# PUBLIC_CLARITY_ID=xxxxxxxxxx
 
 # Hotjar
 # PUBLIC_HOTJAR_ID=1234567

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -93,7 +93,7 @@ function updateLeadinfoConsent(analyticsConsent: boolean): void {
 
 function deleteCookiesByCategory(category: 'analytics' | 'marketing'): void {
   const cookiesToDelete: Record<string, string[]> = {
-    analytics: ['_ga', '_gid', '_li_id', '_li_ses'],
+    analytics: ['_ga', '_gid', '_li_id', '_li_ses', '_clck', '_clsk', 'CLID', 'ANONCHK', 'MR', 'MUID', 'SM'],
     marketing: ['_fbp', '_fbc'],
   };
 
@@ -351,7 +351,7 @@ export function CookieConsent() {
               <div className="flex items-center justify-between p-4 bg-canvas/5 rounded-lg hover:bg-canvas/10 transition-colors">
                 <div>
                   <h3 className="font-semibold">Analytisch</h3>
-                  <p className="text-sm text-canvas/60">Helpt ons de website te verbeteren (Google Analytics, Leadinfo)</p>
+                  <p className="text-sm text-canvas/60">Helpt ons de website te verbeteren (Google Analytics, Clarity, Leadinfo)</p>
                 </div>
                 <button
                   type="button"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -33,6 +33,7 @@ const ogImageURL = new URL(image, Astro.site);
 const GA_MEASUREMENT_ID = 'G-BBR63CY7Q9';
 const META_PIXEL_ID = import.meta.env.PUBLIC_META_PIXEL_ID || '';
 const LEADINFO_ID = 'LI-6973D746ECCF2';
+const CLARITY_ID = 'v6kn03ub4s';
 ---
 
 <!doctype html>
@@ -179,6 +180,17 @@ const LEADINFO_ID = 'LI-6973D746ECCF2';
         'https://connect.facebook.net/en_US/fbevents.js');
         fbq('init', '${META_PIXEL_ID}');
         fbq('track', 'PageView');
+      `} />
+    )}
+
+    {/* Microsoft Clarity - Only loads after analytics consent */}
+    {CLARITY_ID && (
+      <script type="text/plain" data-consent="analytics" set:html={`
+        (function(c,l,a,r,i,t,y){
+          c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+          t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/${CLARITY_ID}";
+          y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script");
       `} />
     )}
   </head>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -339,6 +339,7 @@ import Footer from "../components/Footer.astro";
                             <p>Helpen ons begrijpen hoe bezoekers de website gebruiken.</p>
                             <ul class="list-disc pl-5 space-y-1 mt-2">
                                 <li><code class="text-sm bg-ink/10 px-1 rounded">_ga</code>, <code class="text-sm bg-ink/10 px-1 rounded">_ga_*</code> &ndash; Google Analytics (2 jaar)</li>
+                                <li><code class="text-sm bg-ink/10 px-1 rounded">_clck</code>, <code class="text-sm bg-ink/10 px-1 rounded">_clsk</code> &ndash; Microsoft Clarity heatmaps &amp; sessie-opnames (1 jaar / sessie)</li>
                                 <li><code class="text-sm bg-ink/10 px-1 rounded">_li_id</code>, <code class="text-sm bg-ink/10 px-1 rounded">_li_ses</code> &ndash; Leadinfo sessietracking (1 jaar / sessie)</li>
                             </ul>
 


### PR DESCRIPTION
## Summary
- Add Microsoft Clarity for heatmaps and session recordings
- Script blocked until analytics consent granted (GDPR compliant)
- Clarity cookies added to deletion function for consent withdrawal
- Privacy policy updated with Clarity disclosure

## Test plan
- [ ] Accept analytics cookies
- [ ] Verify Clarity loads (check Network tab for clarity.ms)
- [ ] Check clarity.microsoft.com dashboard for incoming data
- [ ] Revoke consent, verify Clarity cookies deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)