### PR TITLE
feat: restore GDPR consent requirement for tracking scripts ✨

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -149,14 +149,14 @@ const CLARITY_ID = 'v6kn03ub4s';
          Uses type="text/plain" to prevent execution before consent
          ========================================================================= -->
 
-    {/* Google Analytics 4 - TEMPORARY: Loading without consent for setup verification */}
+    {/* Google Analytics 4 - Only loads after analytics consent */}
     {GA_MEASUREMENT_ID && (
       <>
-        <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`} />
-        <script is:inline define:vars={{ GA_MEASUREMENT_ID }} >
+        <script type="text/plain" data-consent="analytics" data-src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`} />
+        <script type="text/plain" data-consent="analytics" set:html={`
           gtag('js', new Date());
-          gtag('config', GA_MEASUREMENT_ID);
-        </script>
+          gtag('config', '${GA_MEASUREMENT_ID}');
+        `} />
       </>
     )}
 
@@ -176,15 +176,15 @@ const CLARITY_ID = 'v6kn03ub4s';
       `} />
     )}
 
-    {/* Microsoft Clarity - TEMPORARY: Loading without consent for setup verification */}
+    {/* Microsoft Clarity - Only loads after analytics consent */}
     {CLARITY_ID && (
-      <script is:inline define:vars={{ CLARITY_ID }}>
+      <script type="text/plain" data-consent="analytics" set:html={`
         (function(c,l,a,r,i,t,y){
           c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-          t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+CLARITY_ID;
+          t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/${CLARITY_ID}";
           y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
         })(window, document, "clarity", "script");
-      </script>
+      `} />
     )}
   </head>
   <body

--- a/src/pages/aanvragen.astro
+++ b/src/pages/aanvragen.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import TextRevealCSS from "../components/TextRevealCSS.astro";
+import Footer from "../components/Footer.astro";
 ---
 
 <Layout
@@ -329,6 +330,7 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 
         </div>
     </main>
+    <Footer />
 </Layout>
 
 <script>

--- a/src/pages/aanvragen/bedankt.astro
+++ b/src/pages/aanvragen/bedankt.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "../../layouts/Layout.astro";
+import Footer from "../../components/Footer.astro";
 ---
 
 <Layout
@@ -44,4 +45,5 @@ import Layout from "../../layouts/Layout.astro";
             </div>
         </div>
     </main>
+    <Footer />
 </Layout>


### PR DESCRIPTION
## Summary
- Revert temporary tracking setup (commit 3a2151a) back to consent-based loading
- GA4 and Microsoft Clarity now require analytics consent before loading
- Add Footer component to aanvragen and bedankt pages

## Test plan
- [ ] Verify tracking scripts don't load until consent is given
- [ ] Check cookie banner still works correctly
- [ ] Confirm Footer appears on /aanvragen and /aanvragen/bedankt pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)