### PR TITLE
docs: add Microsoft Clarity form tracking disclosure 📝

### DIFF
--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -22,10 +22,10 @@ import Footer from "../components/Footer.astro";
                     class="flex flex-col md:flex-row md:items-center gap-4 text-sm font-mono uppercase tracking-widest text-ink/60 border-t border-ink/10 pt-6"
                 >
                     <span class="bg-acid px-2 py-1 text-black font-bold text-xs"
-                        >Versie 2.1</span
+                        >Versie 2.2</span
                     >
                     <span class="hidden md:inline">&mdash;</span>
-                    <span>Laatst bijgewerkt: 20 Januari 2026</span>
+                    <span>Laatst bijgewerkt: 24 Januari 2026</span>
                 </div>
             </header>
 
@@ -175,6 +175,9 @@ import Footer from "../components/Footer.astro";
                                 <li>Google Calendar (agenda-afspraken)</li>
                                 <li>
                                     Google Analytics (websitestatistieken, na toestemming)
+                                </li>
+                                <li>
+                                    Microsoft Clarity (heatmaps, sessie-opnames &amp; formulier-analyse, na toestemming)
                                 </li>
                                 <li>
                                     Leadinfo (B2B-bezoekersidentificatie)
@@ -339,7 +342,7 @@ import Footer from "../components/Footer.astro";
                             <p>Helpen ons begrijpen hoe bezoekers de website gebruiken.</p>
                             <ul class="list-disc pl-5 space-y-1 mt-2">
                                 <li><code class="text-sm bg-ink/10 px-1 rounded">_ga</code>, <code class="text-sm bg-ink/10 px-1 rounded">_ga_*</code> &ndash; Google Analytics (2 jaar)</li>
-                                <li><code class="text-sm bg-ink/10 px-1 rounded">_clck</code>, <code class="text-sm bg-ink/10 px-1 rounded">_clsk</code> &ndash; Microsoft Clarity heatmaps &amp; sessie-opnames (1 jaar / sessie)</li>
+                                <li><code class="text-sm bg-ink/10 px-1 rounded">_clck</code>, <code class="text-sm bg-ink/10 px-1 rounded">_clsk</code> &ndash; Microsoft Clarity heatmaps, sessie-opnames &amp; formulier-analyse (1 jaar / sessie)</li>
                                 <li><code class="text-sm bg-ink/10 px-1 rounded">_li_id</code>, <code class="text-sm bg-ink/10 px-1 rounded">_li_ses</code> &ndash; Leadinfo sessietracking (1 jaar / sessie)</li>
                             </ul>
 


### PR DESCRIPTION
## Summary
- Update privacy policy version 2.1 → 2.2
- Add Microsoft Clarity to third-party vendors section
- Include "formulier-analyse" in Clarity cookie description

## Why
Required for GDPR compliance before enabling Clarity's form tracking feature.

## Test plan
- [ ] Verify privacy page renders correctly
- [ ] Check version badge shows 2.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)