### PR TITLE
fix: remove Leadinfo to fix GDPR consent violation 🐛

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -83,17 +83,10 @@ function updateGoogleConsentMode(categories: ConsentCategories): void {
   }
 }
 
-function updateLeadinfoConsent(analyticsConsent: boolean): void {
-  // Leadinfo runs cookieless by default (Legitimate Interest)
-  // When analytics consent is granted, enable full cookie tracking
-  if (typeof window !== 'undefined' && typeof (window as any).leadinfo === 'function') {
-    (window as any).leadinfo('consent', analyticsConsent);
-  }
-}
 
 function deleteCookiesByCategory(category: 'analytics' | 'marketing'): void {
   const cookiesToDelete: Record<string, string[]> = {
-    analytics: ['_ga', '_gid', '_li_id', '_li_ses', '_clck', '_clsk', 'CLID', 'ANONCHK', 'MR', 'MUID', 'SM'],
+    analytics: ['_ga', '_gid', '_clck', '_clsk', 'CLID', 'ANONCHK', 'MR', 'MUID', 'SM'],
     marketing: ['_fbp', '_fbc'],
   };
 
@@ -237,9 +230,6 @@ export function CookieConsent() {
     // Update Google Consent Mode
     updateGoogleConsentMode(cats);
 
-    // Update Leadinfo consent (upgrades from cookieless to full tracking)
-    updateLeadinfoConsent(cats.analytics);
-
     // Enable blocked scripts based on consent
     if (cats.analytics) enableBlockedScripts('analytics');
     if (cats.marketing) enableBlockedScripts('marketing');
@@ -352,7 +342,7 @@ export function CookieConsent() {
               <div className="flex items-center justify-between p-4 bg-canvas/5 rounded-lg hover:bg-canvas/10 transition-colors">
                 <div>
                   <h3 className="font-semibold">Analytisch</h3>
-                  <p className="text-sm text-canvas/60">Helpt ons de website te verbeteren (Google Analytics, Clarity, Leadinfo)</p>
+                  <p className="text-sm text-canvas/60">Helpt ons de website te verbeteren (Google Analytics, Clarity)</p>
                 </div>
                 <button
                   type="button"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -32,7 +32,6 @@ const ogImageURL = new URL(image, Astro.site);
 // =============================================================================
 const GA_MEASUREMENT_ID = 'G-BBR63CY7Q9';
 const META_PIXEL_ID = import.meta.env.PUBLIC_META_PIXEL_ID || '';
-const LEADINFO_ID = 'LI-6973D746ECCF2';
 const CLARITY_ID = 'v6kn03ub4s';
 ---
 
@@ -68,16 +67,6 @@ const CLARITY_ID = 'v6kn03ub4s';
       gtag("set", "url_passthrough", true);
     </script>
 
-    <!-- =========================================================================
-         LEADINFO - Loads immediately in cookieless mode (Legitimate Interest)
-         Upgrades to full tracking after analytics consent granted
-         ========================================================================= -->
-    <script is:inline define:vars={{ LEADINFO_ID }}>
-      (function(l,e,a,d,i,n,f,o){if(!l[i]){l.GlobalLeadinfoNamespace=l.GlobalLeadinfoNamespace||[];
-      l.GlobalLeadinfoNamespace.push(i);l[i]=function(){(l[i].q=l[i].q||[]).push(arguments)};l[i].t=l[i].t||n;
-      l[i].q=l[i].q||[];o=e.createElement(a);f=e.getElementsByTagName(a)[0];o.async=1;o.src=d;f.parentNode.insertBefore(o,f);}
-      }(window,document,'script','https://cdn.leadinfo.net/ping.js','leadinfo',LEADINFO_ID));
-    </script>
     <link rel="icon" type="image/svg+xml" href="/favicon_final.svg" />
     <!-- Preload all font weights - ensures they arrive within 100ms for font-display: optional -->
     <link rel="preload" href={interTight400} as="font" type="font/woff2" crossorigin />

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -22,7 +22,7 @@ import Footer from "../components/Footer.astro";
                     class="flex flex-col md:flex-row md:items-center gap-4 text-sm font-mono uppercase tracking-widest text-ink/60 border-t border-ink/10 pt-6"
                 >
                     <span class="bg-acid px-2 py-1 text-black font-bold text-xs"
-                        >Versie 2.2</span
+                        >Versie 2.3</span
                     >
                     <span class="hidden md:inline">&mdash;</span>
                     <span>Laatst bijgewerkt: 24 Januari 2026</span>
@@ -178,9 +178,6 @@ import Footer from "../components/Footer.astro";
                                 </li>
                                 <li>
                                     Microsoft Clarity (heatmaps, sessie-opnames &amp; formulier-analyse, na toestemming)
-                                </li>
-                                <li>
-                                    Leadinfo (B2B-bezoekersidentificatie)
                                 </li>
                                 <li>
                                     n8n (zelf gehoste workflow-automatisering)
@@ -343,7 +340,6 @@ import Footer from "../components/Footer.astro";
                             <ul class="list-disc pl-5 space-y-1 mt-2">
                                 <li><code class="text-sm bg-ink/10 px-1 rounded">_ga</code>, <code class="text-sm bg-ink/10 px-1 rounded">_ga_*</code> &ndash; Google Analytics (2 jaar)</li>
                                 <li><code class="text-sm bg-ink/10 px-1 rounded">_clck</code>, <code class="text-sm bg-ink/10 px-1 rounded">_clsk</code> &ndash; Microsoft Clarity heatmaps, sessie-opnames &amp; formulier-analyse (1 jaar / sessie)</li>
-                                <li><code class="text-sm bg-ink/10 px-1 rounded">_li_id</code>, <code class="text-sm bg-ink/10 px-1 rounded">_li_ses</code> &ndash; Leadinfo sessietracking (1 jaar / sessie)</li>
                             </ul>
 
                             <p class="mt-4"><strong class="text-ink">Marketingcookies</strong> (na toestemming):</p>
@@ -351,22 +347,6 @@ import Footer from "../components/Footer.astro";
                             <ul class="list-disc pl-5 space-y-1 mt-2">
                                 <li><code class="text-sm bg-ink/10 px-1 rounded">_fbp</code> &ndash; Meta Pixel (3 maanden)</li>
                             </ul>
-
-                            <p class="mt-4"><strong class="text-ink">B2B-identificatie (Leadinfo)</strong></p>
-                            <p>
-                                Wij gebruiken Leadinfo om zakelijke bezoekers te identificeren
-                                op basis van IP-adres. Dit verwerken wij op grond van ons
-                                gerechtvaardigd belang. Wij identificeren alleen bedrijven,
-                                geen individuele personen. Met toestemming worden aanvullende
-                                cookies geplaatst voor sessietracking. Je kunt bezwaar maken via:
-                                <a
-                                    href="https://www.leadinfo.com/en/opt-out"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    class="text-ink underline decoration-acid decoration-2 underline-offset-4 hover:bg-acid hover:decoration-transparent transition-colors"
-                                    >leadinfo.com/opt-out</a
-                                >.
-                            </p>
 
                             <p class="mt-4"><strong class="text-ink">Cloudflare</strong></p>
                             <p>


### PR DESCRIPTION
## Summary
- Remove Leadinfo completely (was loading before consent without cookieless mode)
- Remove all Leadinfo references from CookieConsent.tsx
- Update privacy policy (version 2.3)

## Why
Leadinfo was set to load immediately assuming "cookieless mode" was enabled, but it wasn't configured in the Leadinfo dashboard. This meant cookies were being set without consent = GDPR violation.

## Test plan
- [ ] Verify no Leadinfo script in page source
- [ ] Confirm cookie consent still works for GA/Clarity
- [ ] Check privacy policy shows version 2.3

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)