### PR TITLE
fix: integrate Microsoft Clarity Consent API v2 🐛

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -83,6 +83,21 @@ function updateGoogleConsentMode(categories: ConsentCategories): void {
   }
 }
 
+function updateClarityConsent(analyticsConsent: boolean): void {
+  if (typeof window === 'undefined' || typeof (window as any).clarity !== 'function') return;
+
+  if (analyticsConsent) {
+    // Grant consent - Clarity can set cookies and track across sessions
+    (window as any).clarity('consentv2', {
+      ad_Storage: 'granted',
+      analytics_Storage: 'granted',
+    });
+  } else {
+    // Revoke consent - Clarity clears its cookies
+    (window as any).clarity('consent', false);
+  }
+}
+
 
 function deleteCookiesByCategory(category: 'analytics' | 'marketing'): void {
   const cookiesToDelete: Record<string, string[]> = {
@@ -229,6 +244,9 @@ export function CookieConsent() {
   const applyConsent = useCallback((cats: ConsentCategories) => {
     // Update Google Consent Mode
     updateGoogleConsentMode(cats);
+
+    // Update Microsoft Clarity consent (v2 API)
+    updateClarityConsent(cats.analytics);
 
     // Enable blocked scripts based on consent
     if (cats.analytics) enableBlockedScripts('analytics');


### PR DESCRIPTION
## Summary
Integrates Microsoft Clarity's Consent API v2 for proper GDPR compliance.

## Changes
- Add `updateClarityConsent()` function
- Call `clarity('consentv2', {...})` when consent granted
- Call `clarity('consent', false)` to revoke and clear cookies

## Why
Per [Microsoft's documentation](https://learn.microsoft.com/en-us/clarity/setup-and-installation/clarity-consent-api-v2), Clarity requires explicit consent API calls to properly manage cookies. Simply blocking/unblocking the script isn't enough - we must call the API so Clarity can clear its cookies when consent is revoked.

## Test plan
- [ ] Grant consent → verify Clarity tracks session
- [ ] Revoke consent → verify Clarity cookies are cleared
- [ ] Check Clarity dashboard still receives data

🤖 Generated with [Claude Code](https://claude.com/claude-code)