### PR TITLE
fix: fix Clarity consent API timing issue 🐛

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -242,15 +242,18 @@ export function CookieConsent() {
   }, []);
 
   const applyConsent = useCallback((cats: ConsentCategories) => {
-    // Update Google Consent Mode
+    // Update Google Consent Mode (Clarity auto-detects this)
     updateGoogleConsentMode(cats);
-
-    // Update Microsoft Clarity consent (v2 API)
-    updateClarityConsent(cats.analytics);
 
     // Enable blocked scripts based on consent
     if (cats.analytics) enableBlockedScripts('analytics');
     if (cats.marketing) enableBlockedScripts('marketing');
+
+    // Update Microsoft Clarity consent AFTER scripts load
+    // Small delay ensures Clarity script has initialized
+    setTimeout(() => {
+      updateClarityConsent(cats.analytics);
+    }, 500);
 
     // Delete cookies when consent is revoked
     if (!cats.analytics) deleteCookiesByCategory('analytics');


### PR DESCRIPTION
## Problem
The Clarity consent API was being called BEFORE the Clarity script loaded, causing it to silently fail (window.clarity didn't exist yet).

## Fix
Move `updateClarityConsent()` call to happen 500ms AFTER `enableBlockedScripts()` to ensure Clarity has initialized.

## Test plan
- [ ] Accept cookies
- [ ] Check if Clarity cookies appear after ~500ms
- [ ] Verify session still tracked in Clarity dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)