### PR TITLE
fix(a11y): increase text contrast in pricing cards 🐛

### DIFF
--- a/src/components/OfferSection.astro
+++ b/src/components/OfferSection.astro
@@ -23,13 +23,13 @@
 
 			<!-- TIER 1: Start -->
 			<div class="border-2 border-ink/10 p-6 lg:p-8 flex flex-col bg-canvas hover:border-ink/20 transition-colors">
-				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-6">
+				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-6">
 					[ Start ]
 				</div>
 
 				<div class="mb-6">
 					<span class="text-4xl lg:text-5xl font-black tracking-tight leading-none">€595</span>
-					<p class="text-ink/40 font-mono text-xs mt-2">eenmalig excl. BTW</p>
+					<p class="text-ink/60 font-mono text-xs mt-2">eenmalig excl. BTW</p>
 				</div>
 
 				<p class="text-ink/60 text-sm mb-6 leading-relaxed">
@@ -61,8 +61,8 @@
 
 				<div class="border-t border-ink/10 pt-4 mb-6">
 					<div class="flex items-baseline justify-between">
-						<span class="text-xs font-mono uppercase tracking-wider text-ink/40">Maandelijks</span>
-						<span class="font-bold">€29<span class="font-normal text-ink/40">/mo</span></span>
+						<span class="text-xs font-mono uppercase tracking-wider text-ink/60">Maandelijks</span>
+						<span class="font-bold">€29<span class="font-normal text-ink/60">/mo</span></span>
 					</div>
 				</div>
 
@@ -87,7 +87,7 @@
 
 				<div class="mb-6">
 					<span class="text-4xl lg:text-5xl font-black tracking-tight leading-none">€1.295</span>
-					<p class="text-ink/50 font-mono text-xs mt-2">eenmalig excl. BTW</p>
+					<p class="text-ink/70 font-mono text-xs mt-2">eenmalig excl. BTW</p>
 				</div>
 
 				<p class="text-ink/70 text-sm mb-6 leading-relaxed font-medium">
@@ -119,8 +119,8 @@
 
 				<div class="border-t border-ink/20 pt-4 mb-6">
 					<div class="flex items-baseline justify-between">
-						<span class="text-xs font-mono uppercase tracking-wider text-ink/50">Maandelijks</span>
-						<span class="font-bold">€59<span class="font-normal text-ink/50">/mo</span></span>
+						<span class="text-xs font-mono uppercase tracking-wider text-ink/70">Maandelijks</span>
+						<span class="font-bold">€59<span class="font-normal text-ink/70">/mo</span></span>
 					</div>
 				</div>
 
@@ -134,13 +134,13 @@
 
 			<!-- TIER 3: Systeem -->
 			<div class="border-2 border-ink bg-ink text-canvas p-6 lg:p-8 flex flex-col">
-				<div class="text-xs font-mono uppercase tracking-[0.2em] text-canvas/40 mb-6">
+				<div class="text-xs font-mono uppercase tracking-[0.2em] text-canvas/60 mb-6">
 					[ Systeem ]
 				</div>
 
 				<div class="mb-6">
 					<span class="text-4xl lg:text-5xl font-black tracking-tight leading-none">€1.895</span>
-					<p class="text-canvas/40 font-mono text-xs mt-2">eenmalig excl. BTW</p>
+					<p class="text-canvas/60 font-mono text-xs mt-2">eenmalig excl. BTW</p>
 				</div>
 
 				<p class="text-canvas/60 text-sm mb-6 leading-relaxed">
@@ -172,8 +172,8 @@
 
 				<div class="border-t border-canvas/20 pt-4 mb-6">
 					<div class="flex items-baseline justify-between">
-						<span class="text-xs font-mono uppercase tracking-wider text-canvas/40">Maandelijks</span>
-						<span class="font-bold text-acid">€99<span class="font-normal text-canvas/40">/mo</span></span>
+						<span class="text-xs font-mono uppercase tracking-wider text-canvas/60">Maandelijks</span>
+						<span class="font-bold text-acid">€99<span class="font-normal text-canvas/60">/mo</span></span>
 					</div>
 				</div>
 


### PR DESCRIPTION
## Summary
- Increase opacity values for low-contrast text in pricing cards to meet WCAG AA requirements (4.5:1 minimum ratio)
- Fix all 8 failing elements flagged by Google Lighthouse accessibility audit

## Changes
| Card | Element | Before | After |
|------|---------|--------|-------|
| START | `[ Start ]` label | `/40` | `/60` |
| START | "eenmalig excl. BTW", "Maandelijks", "/mo" | `/40` | `/60` |
| SLIM | "eenmalig excl. BTW", "Maandelijks", "/mo" | `/50` | `/70` |
| SYSTEEM | `[ Systeem ]` label | `/40` | `/60` |
| SYSTEEM | "eenmalig excl. BTW", "Maandelijks", "/mo" | `/40` | `/60` |

## Test plan
- [ ] Run Lighthouse accessibility audit on homepage pricing section
- [ ] Verify score reaches 100/100
- [ ] Visual check that text remains readable and consistent

Closes #134

🤖 Generated with [Claude Code](https://claude.ai/code)