### PR TITLE
feat(copy): update hero subheadline and CTAs for solo positioning ✨

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -61,7 +61,7 @@ const isActive = (href: string) => {
                     href="/aanvragen"
                     class="btn-bracket btn-bracket-ink bg-acid text-ink px-5 py-2.5 font-bold uppercase tracking-tight text-sm hover:bg-ink hover:text-acid transition-colors duration-300"
                 >
-                    Strategie-Gesprek
+                    Kennismaken
                 </a>
             </nav>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,7 +53,7 @@ const cities = getAllCities();
 
 				<!-- Subheadline - static -->
 				<p class="text-lg md:text-xl lg:text-2xl text-ink/70 max-w-2xl mb-10 md:mb-12 leading-relaxed">
-					Je digitale medewerker. Vangt leads, plant afspraken, vraagt reviews. Terwijl jij onderneemt.
+					Een slimme website die reviews verzamelt, afspraken boekt en leads opvolgt. Terwijl jij onderneemt.
 				</p>
 
 				<!-- CTA -->
@@ -61,8 +61,7 @@ const cities = getAllCities();
 					href="/aanvragen"
 					class="btn-bracket btn-bracket-ink w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group mb-12 md:mb-16"
 				>
-					<span class="sm:hidden">Plan Je Strategie-Gesprek</span>
-					<span class="hidden sm:inline">Plan Je Gratis Strategie-Gesprek</span>
+				Laten we kennismaken
 					<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 				</a>
 


### PR DESCRIPTION
## Summary
- Update hero subheadline from "digitale medewerker" to "slimme website" positioning
- Change hero CTA to friendlier "Laten we kennismaken"
- Update nav CTA to "Kennismaken"

## Changes
| Element | Before | After |
|---------|--------|-------|
| Subheadline | Je digitale medewerker. Vangt leads, plant afspraken, vraagt reviews. | Een slimme website die reviews verzamelt, afspraken boekt en leads opvolgt. |
| Hero CTA | Plan Je (Gratis) Strategie-Gesprek | Laten we kennismaken |
| Nav CTA | Strategie-Gesprek | Kennismaken |

## Test plan
- [ ] Verify hero section displays new subheadline
- [ ] Verify hero CTA button shows "Laten we kennismaken"
- [ ] Verify desktop nav CTA shows "Kennismaken"
- [ ] Check mobile responsiveness

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)