### PR TITLE
feat(copy): standardize all CTAs to solo entrepreneur positioning ✨

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -124,7 +124,7 @@ const isActive = (href: string) => {
             style={`--index: ${navLinks.length}`}
         >
             <span class="relative z-10 block bg-acid text-ink px-8 py-4 font-black text-xl uppercase tracking-tight transition-all duration-300 group-hover:bg-canvas">
-                Strategie-Gesprek
+                Kennismaken
             </span>
             <span class="absolute inset-0 bg-electric scale-x-0 origin-left transition-transform duration-500 group-hover:scale-x-100"></span>
         </a>

--- a/src/pages/aanvragen.astro
+++ b/src/pages/aanvragen.astro
@@ -5,8 +5,8 @@ import Footer from "../components/Footer.astro";
 ---
 
 <Layout
-	title="Plan Je Gratis Strategie-Gesprek | Website €595 | KNAP GEMAAKT."
-	description="Plan een gratis strategie-gesprek en start met je nieuwe website. ✓ Binnen 7 dagen live ✓ €595 vast ✓ Geen verplichtingen. Wij bellen jou!"
+	title="Laten We Kennismaken | Website €595 | KNAP GEMAAKT."
+	description="Plan een vrijblijvend gesprek en start met je nieuwe website. ✓ Binnen 7 dagen live ✓ €595 vast ✓ Geen verplichtingen."
 >
     <main class="min-h-screen bg-canvas pt-32 pb-24 px-4 md:px-8 bg-grid-light relative overflow-hidden">
         <div class="max-w-4xl mx-auto">
@@ -285,10 +285,7 @@ import Footer from "../components/Footer.astro";
                         id="submit-btn"
                         class="btn-bracket btn-bracket-ink w-full md:w-auto px-8 py-5 bg-acid text-ink font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                        <span id="btn-text">
-                            <span class="sm:hidden">Plan Je Strategie-Gesprek</span>
-                            <span class="hidden sm:inline">Plan Je Gratis Strategie-Gesprek</span>
-                        </span>
+                        <span id="btn-text">Laten we kennismaken</span>
                         <span id="btn-arrow" class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
                         <span id="btn-loading" class="hidden">
                             <svg

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -149,15 +149,14 @@ const breadcrumbs = [
 						Hulp Nodig Bij Je Website?
 					</h2>
 					<p class="text-ink/60 mb-6 max-w-lg mx-auto">
-						Wil je weten wat wij voor jouw bedrijf kunnen betekenen?
-						Plan een gratis strategie-gesprek en we bespreken de mogelijkheden.
+						Wil je weten wat ik voor jouw bedrijf kan betekenen?
+						Laten we even sparren over de mogelijkheden.
 					</p>
 					<a
 						href="/aanvragen"
 						class="btn-bracket btn-bracket-ink bg-acid text-ink px-8 py-4 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 					>
-						<span class="sm:hidden">Plan Je Strategie-Gesprek</span>
-						<span class="hidden sm:inline">Plan Je Gratis Strategie-Gesprek</span>
+						Laten we kennismaken
 						<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 					</a>
 				</div>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -108,14 +108,13 @@ const breadcrumbs = [
 				</h2>
 				<p class="text-xl text-ink/60 max-w-2xl mx-auto mb-8">
 					Na al dat lezen ben je misschien wel klaar om de stap te zetten.
-					Plan een gratis strategie-gesprek en ontdek wat wij voor jouw bedrijf kunnen betekenen.
+					Laten we even sparren over wat ik voor jouw bedrijf kan betekenen.
 				</p>
 				<a
 					href="/aanvragen"
 					class="btn-bracket btn-bracket-ink bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 				>
-					<span class="sm:hidden">Plan Je Strategie-Gesprek</span>
-					<span class="hidden sm:inline">Plan Je Gratis Strategie-Gesprek</span>
+					Laten we kennismaken
 					<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 				</a>
 			</div>

--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -130,14 +130,13 @@ const breadcrumbs = [
 				</h2>
 				<p class="text-xl text-ink/60 max-w-2xl mx-auto mb-8">
 					Na al dat lezen ben je misschien wel klaar om de stap te zetten.
-					Plan een gratis strategie-gesprek en ontdek wat wij voor jouw bedrijf kunnen betekenen.
+					Laten we even sparren over wat ik voor jouw bedrijf kan betekenen.
 				</p>
 				<a
 					href="/aanvragen"
 					class="btn-bracket btn-bracket-ink bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 				>
-					<span class="sm:hidden">Plan Je Strategie-Gesprek</span>
-					<span class="hidden sm:inline">Plan Je Gratis Strategie-Gesprek</span>
+					Laten we kennismaken
 					<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 				</a>
 			</div>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -95,14 +95,13 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 						Klaar om te starten?
 					</h2>
 					<p class="text-canvas/60 text-lg mb-8 max-w-xl mx-auto">
-						Plan een gratis strategie-gesprek en ontdek hoe wij jouw website binnen 7 dagen kunnen bouwen.
+						Laten we even sparren over hoe ik jouw website binnen 7 dagen kan bouwen.
 					</p>
 					<a
 						href="/aanvragen"
 						class="btn-bracket btn-bracket-acid inline-flex items-center justify-center gap-3 px-8 py-[18px] bg-acid text-ink font-bold uppercase tracking-tight hover:bg-acid/80 transition-colors duration-300 group"
 					>
-						<span class="sm:hidden">Plan Je Strategie-Gesprek</span>
-						<span class="hidden sm:inline">Plan Je Gratis Strategie-Gesprek</span>
+						Laten we kennismaken
 						<span class="text-xl leading-none transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 					</a>
 				</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -296,8 +296,7 @@ const cities = getAllCities();
 						href="/aanvragen"
 						class="btn-bracket btn-bracket-ink bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 					>
-						<span class="sm:hidden">Plan Je Strategie-Gesprek</span>
-						<span class="hidden sm:inline">Plan Je Gratis Strategie-Gesprek</span>
+					Laten we kennismaken
 						<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 					</a>
 				</div>

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -194,8 +194,7 @@ const breadcrumbs = [
                             href="/aanvragen"
                             class="btn-bracket btn-bracket-ink w-full sm:w-auto bg-ink text-acid px-8 py-4 font-bold uppercase tracking-tight hover:bg-ink/80 transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
                         >
-                            <span class="sm:hidden">Plan Je Strategie-Gesprek</span>
-                            <span class="hidden sm:inline">Plan Je Gratis Strategie-Gesprek</span>
+                            Laten we kennismaken
                             <span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
                         </a>
                     </div>

--- a/src/pages/webdesign-[city].astro
+++ b/src/pages/webdesign-[city].astro
@@ -81,8 +81,7 @@ const breadcrumbs = [
                             href="/aanvragen"
                             class="btn-bracket btn-bracket-ink w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
                         >
-                            <span class="sm:hidden">Plan Je Strategie-Gesprek</span>
-                            <span class="hidden sm:inline">Plan Je Gratis Strategie-Gesprek</span>
+                            Laten we kennismaken
                             <span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
                         </a>
                     </div>

--- a/src/pages/website-laten-maken.astro
+++ b/src/pages/website-laten-maken.astro
@@ -33,7 +33,7 @@ const faqs = [
 
 <Layout
 	title="Website Laten Maken | €595 Vast | 7 Dagen Live | KNAP GEMAAKT."
-	description="Website laten maken die voor je werkt? Een digitale medewerker die klanten boekt en leads vangt. €595 vast, binnen 7 dagen live. Plan je gratis strategie-gesprek."
+	description="Website laten maken die voor je werkt? Een slimme website die klanten boekt en leads vangt. €595 vast, binnen 7 dagen live."
 >
 	<LocalBusinessSchema />
 	<FAQSchema faqs={faqs} />
@@ -66,8 +66,7 @@ const faqs = [
 					href="/aanvragen"
 					class="btn-bracket btn-bracket-ink w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group mb-12 md:mb-16"
 				>
-					<span class="sm:hidden">Plan Je Strategie-Gesprek</span>
-					<span class="hidden sm:inline">Plan Je Gratis Strategie-Gesprek</span>
+					Laten we kennismaken
 					<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 				</a>
 
@@ -210,8 +209,7 @@ const faqs = [
 						href="/aanvragen"
 						class="btn-bracket btn-bracket-ink bg-ink text-canvas px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink/80 transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 					>
-						<span class="sm:hidden">Plan Je Strategie-Gesprek</span>
-						<span class="hidden sm:inline">Plan Je Gratis Strategie-Gesprek</span>
+						Laten we kennismaken
 						<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 					</a>
 				</div>
@@ -335,15 +333,14 @@ const faqs = [
 					Klaar Om Te Beginnen?
 				</h2>
 				<p class="text-canvas/70 text-lg mb-10 max-w-xl mx-auto">
-					Plan een gratis strategie-gesprek. 15 minuten, geen verplichtingen.
+					Laten we even sparren. 15 minuten, geen verplichtingen.
 					Je kiest zelf een moment dat jou uitkomt.
 				</p>
 				<a
 					href="/aanvragen"
 					class="btn-bracket btn-bracket-acid bg-acid text-ink px-10 py-6 font-bold uppercase tracking-tight text-xl hover:bg-acid/80 transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 				>
-					<span class="sm:hidden">Plan Je Strategie-Gesprek</span>
-					<span class="hidden sm:inline">Plan Je Gratis Strategie-Gesprek</span>
+					Laten we kennismaken
 					<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 				</a>
 			</div>


### PR DESCRIPTION
## Summary
Continues the solo entrepreneur positioning from #138. Standardizes all remaining CTAs across the site.

## Changes

### CTA Button Text
| Before | After |
|--------|-------|
| Plan Je (Gratis) Strategie-Gesprek | Laten we kennismaken |
| Strategie-Gesprek | Kennismaken |

### Supporting Text Voice
| Before | After |
|--------|-------|
| "wat wij voor jouw bedrijf kunnen betekenen" | "wat ik voor jouw bedrijf kan betekenen" |
| "hoe wij jouw website kunnen bouwen" | "hoe ik jouw website kan bouwen" |
| "Plan een gratis strategie-gesprek" | "Laten we even sparren" |

### Files Updated (10 total)
- `src/components/Header.astro` - mobile nav CTA
- `src/pages/index.astro` - final CTA section
- `src/pages/aanvragen.astro` - page title, meta, button
- `src/pages/contact.astro` - CTA + supporting text
- `src/pages/portfolio.astro` - bottom CTA
- `src/pages/blog/index.astro` - CTA + supporting text
- `src/pages/blog/[slug].astro` - article footer CTA
- `src/pages/blog/tag/[tag].astro` - CTA + supporting text
- `src/pages/webdesign-[city].astro` - hero CTA
- `src/pages/website-laten-maken.astro` - 3 CTAs + meta

## Test plan
- [ ] Verify all CTA buttons show "Laten we kennismaken" or "Kennismaken"
- [ ] Check mobile nav CTA text
- [ ] Verify supporting text uses "ik/mij" voice
- [ ] Test on mobile for proper button sizing

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)