### PR TITLE
feat(nav): restructure navigation for solo entrepreneur positioning ✨

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -13,10 +13,12 @@ const { variant = "default" } = Astro.props;
 const currentPath = Astro.url.pathname;
 
 const navLinks = [
-    { href: "/portfolio", label: "Portfolio" },
-    { href: "/blog", label: "Blog" },
-    { href: "/#prijzen", label: "Prijzen" },
-    { href: "/#faq", label: "FAQ" },
+    { href: "/website-laten-maken", label: "Websites" },
+    { href: "/aanpak", label: "Aanpak" },
+    { href: "/portfolio", label: "Projecten" },
+    { href: "/blog", label: "Kennis" },
+    { href: "/over-mij", label: "Over Mij" },
+    { href: "/contact", label: "Contact" },
 ];
 
 const isActive = (href: string) => {
@@ -58,10 +60,10 @@ const isActive = (href: string) => {
                     </a>
                 ))}
                 <a
-                    href="/aanvragen"
-                    class="btn-bracket btn-bracket-ink bg-acid text-ink px-5 py-2.5 font-bold uppercase tracking-tight text-sm hover:bg-ink hover:text-acid transition-colors duration-300"
+                    href="/contact"
+                    class="border border-ink/30 text-ink px-5 py-2.5 font-bold uppercase tracking-tight text-sm hover:border-ink hover:bg-ink hover:text-canvas transition-all duration-300"
                 >
-                    Kennismaken
+                    Stuur Bericht
                 </a>
             </nav>
 
@@ -124,7 +126,7 @@ const isActive = (href: string) => {
             style={`--index: ${navLinks.length}`}
         >
             <span class="relative z-10 block bg-acid text-ink px-8 py-4 font-black text-xl uppercase tracking-tight transition-all duration-300 group-hover:bg-canvas">
-                Kennismaken
+                Stuur Bericht
             </span>
             <span class="absolute inset-0 bg-electric scale-x-0 origin-left transition-transform duration-500 group-hover:scale-x-100"></span>
         </a>

--- a/src/pages/aanpak.astro
+++ b/src/pages/aanpak.astro
@@ -1,0 +1,148 @@
+---
+export const prerender = true;
+
+import Layout from "../layouts/Layout.astro";
+import Footer from "../components/Footer.astro";
+import TextRevealCSS from "../components/TextRevealCSS.astro";
+
+const steps = [
+	{
+		number: "01",
+		title: "Kennismaken",
+		description: "We starten met een kort gesprek. Ik luister naar je wensen, je doelgroep en wat je website moet bereiken. Geen verkooppraatje, gewoon even sparren.",
+		duration: "20 min"
+	},
+	{
+		number: "02",
+		title: "Input Verzamelen",
+		description: "Je vult een korte vragenlijst in en deelt je logo, foto's en andere materialen. Heb je geen teksten? Geen probleem, ik schrijf ze voor je.",
+		duration: "30 min"
+	},
+	{
+		number: "03",
+		title: "Ontwerp & Bouw",
+		description: "Ik ga aan de slag. Je hoeft niks te doen. Binnen een week ontvang je een link naar je nieuwe website op een testomgeving.",
+		duration: "5-7 dagen"
+	},
+	{
+		number: "04",
+		title: "Feedback & Finetunen",
+		description: "Je bekijkt het resultaat en geeft feedback. Kleine aanpassingen, andere foto, tekst tweaken? Ik verwerk het dezelfde dag.",
+		duration: "1-2 dagen"
+	},
+	{
+		number: "05",
+		title: "Live!",
+		description: "Na je goedkeuring gaat de website live. Ik regel de technische kant: domein, hosting, SSL, alles. Jij hoeft alleen te delen op social media.",
+		duration: "1 dag"
+	}
+];
+---
+
+<Layout
+	title="Mijn Aanpak | Hoe Ik Werk | KNAP GEMAAKT."
+	description="Van eerste gesprek tot live website in 7 dagen. Ontdek mijn werkwijze: geen eindeloze meetings, geen gedoe. Gewoon een website die werkt."
+>
+	<main class="min-h-screen bg-canvas pt-32 pb-24 px-4 md:px-8 bg-grid-light relative overflow-hidden">
+		<div class="max-w-5xl mx-auto">
+			<!-- Header -->
+			<div class="mb-16 md:mb-24">
+				<TextRevealCSS
+					text="Mijn Aanpak."
+					class="text-5xl md:text-8xl font-black uppercase tracking-tighter leading-none mb-6"
+				/>
+				<p class="text-xl md:text-2xl text-ink/60 font-medium max-w-2xl leading-relaxed">
+					Van eerste gesprek tot live website. Geen eindeloze vergaderingen, geen gedoe.
+					In 5 stappen online.
+				</p>
+			</div>
+
+			<!-- Process Timeline -->
+			<div class="space-y-8 md:space-y-0 md:relative mb-24">
+				<!-- Vertical line (desktop) -->
+				<div class="hidden md:block absolute left-[60px] top-8 bottom-8 w-px bg-gradient-to-b from-acid via-electric to-acid opacity-30"></div>
+
+				{steps.map((step, index) => (
+					<div class="relative md:pl-32 md:pb-16 last:pb-0">
+						<!-- Number badge -->
+						<div class="md:absolute md:left-0 md:top-0 w-[120px] h-[120px] md:w-[120px] md:h-[120px] bg-ink text-canvas flex flex-col items-center justify-center mb-6 md:mb-0">
+							<span class="font-mono text-sm text-acid">{step.number}</span>
+							<span class="text-2xl font-black uppercase tracking-tight">{step.title}</span>
+						</div>
+
+						<!-- Content -->
+						<div class="md:ml-8 p-6 md:p-8 border-2 border-ink/10 hover:border-ink/20 transition-colors">
+							<div class="flex items-start justify-between gap-4 mb-4">
+								<h3 class="text-xl md:text-2xl font-black uppercase tracking-tight md:hidden">
+									{step.title}
+								</h3>
+								<span class="font-mono text-xs text-ink/40 uppercase tracking-widest shrink-0">
+									{step.duration}
+								</span>
+							</div>
+							<p class="text-ink/70 leading-relaxed">
+								{step.description}
+							</p>
+						</div>
+					</div>
+				))}
+			</div>
+
+			<!-- What Makes It Different -->
+			<div class="grid md:grid-cols-3 gap-6 mb-24">
+				<div class="p-6 border-2 border-ink/10">
+					<div class="w-10 h-10 bg-acid flex items-center justify-center mb-4">
+						<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">
+							<circle cx="12" cy="12" r="10"/>
+							<polyline points="12 6 12 12 16 14"/>
+						</svg>
+					</div>
+					<h3 class="font-bold uppercase tracking-tight mb-2">Snel</h3>
+					<p class="text-sm text-ink/60">Geen weken wachten. Je website is binnen 7 dagen live.</p>
+				</div>
+
+				<div class="p-6 border-2 border-ink/10">
+					<div class="w-10 h-10 bg-acid flex items-center justify-center mb-4">
+						<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">
+							<path d="M12 2v20M2 12h20"/>
+						</svg>
+					</div>
+					<h3 class="font-bold uppercase tracking-tight mb-2">Direct Contact</h3>
+					<p class="text-sm text-ink/60">Je praat met mij, niet met een projectmanager. Korte lijnen, snelle beslissingen.</p>
+				</div>
+
+				<div class="p-6 border-2 border-ink/10">
+					<div class="w-10 h-10 bg-acid flex items-center justify-center mb-4">
+						<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">
+							<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/>
+							<polyline points="22 4 12 14.01 9 11.01"/>
+						</svg>
+					</div>
+					<h3 class="font-bold uppercase tracking-tight mb-2">Geen Gedoe</h3>
+					<p class="text-sm text-ink/60">Ik regel alles: design, teksten, hosting, domein. Jij keurt goed en gaat live.</p>
+				</div>
+			</div>
+
+			<!-- CTA Section -->
+			<div class="p-8 md:p-12 bg-ink text-canvas relative overflow-hidden">
+				<div class="absolute inset-0 bg-grid-dark opacity-50"></div>
+				<div class="relative z-10 text-center">
+					<h2 class="text-2xl md:text-4xl font-black uppercase tracking-tighter mb-4">
+						Klinkt Goed?
+					</h2>
+					<p class="text-canvas/60 text-lg mb-8 max-w-xl mx-auto">
+						Laten we kennismaken. Een kort gesprek van 20 minuten, vrijblijvend.
+					</p>
+					<a
+						href="/aanvragen"
+						class="btn-bracket btn-bracket-acid inline-flex items-center justify-center gap-3 px-8 py-[18px] bg-acid text-ink font-bold uppercase tracking-tight hover:bg-acid/80 transition-colors duration-300 group"
+					>
+						Laten we kennismaken
+						<span class="text-xl leading-none transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
+					</a>
+				</div>
+			</div>
+		</div>
+	</main>
+	<Footer />
+</Layout>

--- a/src/pages/over-mij.astro
+++ b/src/pages/over-mij.astro
@@ -1,0 +1,138 @@
+---
+export const prerender = true;
+
+import Layout from "../layouts/Layout.astro";
+import Footer from "../components/Footer.astro";
+import TextRevealCSS from "../components/TextRevealCSS.astro";
+---
+
+<Layout
+	title="Over Mij | Yanni | KNAP GEMAAKT."
+	description="Ik ben Yanni, de persoon achter KNAP GEMAAKT. Ik bouw websites voor ondernemers die geen zin hebben in gedoe. Leer me kennen."
+>
+	<main class="min-h-screen bg-canvas pt-32 pb-24 px-4 md:px-8 bg-grid-light relative overflow-hidden">
+		<div class="max-w-4xl mx-auto">
+			<!-- Header -->
+			<div class="mb-16">
+				<TextRevealCSS
+					text="Over Mij."
+					class="text-5xl md:text-8xl font-black uppercase tracking-tighter leading-none mb-6"
+				/>
+				<p class="text-xl md:text-2xl text-ink/60 font-medium max-w-2xl leading-relaxed">
+					De persoon achter KNAP GEMAAKT.
+				</p>
+			</div>
+
+			<!-- Main Content -->
+			<div class="grid md:grid-cols-3 gap-12 mb-16">
+				<!-- Photo placeholder -->
+				<div class="md:col-span-1">
+					<div class="aspect-square bg-ink/5 border-2 border-ink/10 flex items-center justify-center">
+						<span class="text-ink/20 font-mono text-xs uppercase tracking-widest">Foto</span>
+					</div>
+				</div>
+
+				<!-- Bio -->
+				<div class="md:col-span-2 space-y-6 text-lg text-ink/80 leading-relaxed">
+					<p>
+						Hoi, ik ben <strong class="text-ink">Yanni</strong>. Ik bouw websites voor ondernemers die geen zin hebben in gedoe.
+					</p>
+					<p>
+						Grote bureaus rekenen duizenden euro's en hebben maanden nodig. Goedkope alternatieven
+						leveren trage WordPress-sites die je binnen een jaar hoofdpijn bezorgen.
+						Ik zag een gat in de markt: premium kwaliteit, eerlijke prijs, snel geleverd.
+					</p>
+					<p>
+						Dat is KNAP GEMAAKT. Geen team van 50 man, geen kantoor in Amsterdam, geen
+						projectmanagers die berichten doorspelen. Gewoon ik, die jouw website bouwt.
+					</p>
+					<p>
+						Elke site die ik maak is uniek. Geen templates, geen themes. Ik schrijf de code zelf,
+						en vaak ook de teksten. Want laten we eerlijk zijn: jij bent goed in je vak,
+						niet in het staren naar een leeg Word-document.
+					</p>
+				</div>
+			</div>
+
+			<!-- Values / What I Believe -->
+			<div class="border-t-2 border-ink/10 pt-16 mb-16">
+				<h2 class="text-2xl md:text-3xl font-black uppercase tracking-tighter mb-8">
+					Waar Ik In Geloof
+				</h2>
+				<div class="grid md:grid-cols-2 gap-8">
+					<div class="space-y-2">
+						<h3 class="font-bold uppercase tracking-tight">Geen uurtje-factuurtje</h3>
+						<p class="text-ink/60">Vaste prijzen, geen verrassingen achteraf. Je weet precies wat je betaalt.</p>
+					</div>
+					<div class="space-y-2">
+						<h3 class="font-bold uppercase tracking-tight">Snelheid is respect</h3>
+						<p class="text-ink/60">Jouw tijd is kostbaar. Ik lever snel, zonder concessies aan kwaliteit.</p>
+					</div>
+					<div class="space-y-2">
+						<h3 class="font-bold uppercase tracking-tight">Techniek moet werken</h3>
+						<p class="text-ink/60">Geen trage sites, geen security issues, geen maandelijks onderhoud nodig.</p>
+					</div>
+					<div class="space-y-2">
+						<h3 class="font-bold uppercase tracking-tight">Eerlijk advies</h3>
+						<p class="text-ink/60">Als je geen website nodig hebt, zeg ik dat ook. Ik verkoop geen lucht.</p>
+					</div>
+				</div>
+			</div>
+
+			<!-- Quick Facts -->
+			<div class="grid grid-cols-2 md:grid-cols-4 gap-6 mb-16">
+				<div class="p-6 bg-ink text-canvas text-center">
+					<div class="text-3xl font-black text-acid mb-1">50+</div>
+					<div class="text-xs font-mono uppercase tracking-widest text-canvas/60">Websites gebouwd</div>
+				</div>
+				<div class="p-6 bg-ink text-canvas text-center">
+					<div class="text-3xl font-black text-acid mb-1">7</div>
+					<div class="text-xs font-mono uppercase tracking-widest text-canvas/60">Dagen gemiddeld</div>
+				</div>
+				<div class="p-6 bg-ink text-canvas text-center">
+					<div class="text-3xl font-black text-acid mb-1">100%</div>
+					<div class="text-xs font-mono uppercase tracking-widest text-canvas/60">Tevreden klanten</div>
+				</div>
+				<div class="p-6 bg-ink text-canvas text-center">
+					<div class="text-3xl font-black text-acid mb-1">0</div>
+					<div class="text-xs font-mono uppercase tracking-widest text-canvas/60">WordPress sites</div>
+				</div>
+			</div>
+
+			<!-- Location -->
+			<div class="flex items-center gap-4 p-6 border-2 border-ink/10 mb-16">
+				<div class="w-12 h-12 bg-ink/10 flex items-center justify-center flex-shrink-0">
+					<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">
+						<path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/>
+						<circle cx="12" cy="10" r="3"/>
+					</svg>
+				</div>
+				<div>
+					<h3 class="font-bold uppercase tracking-tight">Gevestigd in Buren, Gelderland</h3>
+					<p class="text-ink/60 text-sm">Maar ik werk met klanten door heel Nederland. Alles gaat remote.</p>
+				</div>
+			</div>
+
+			<!-- CTA Section -->
+			<div class="p-8 md:p-12 bg-ink text-canvas relative overflow-hidden">
+				<div class="absolute inset-0 bg-grid-dark opacity-50"></div>
+				<div class="relative z-10 text-center">
+					<h2 class="text-2xl md:text-4xl font-black uppercase tracking-tighter mb-4">
+						Zullen We Kennismaken?
+					</h2>
+					<p class="text-canvas/60 text-lg mb-8 max-w-xl mx-auto">
+						Vertel me over je project. 20 minuten, geen verkooppraatje.
+					</p>
+					<a
+						href="/aanvragen"
+						class="btn-bracket btn-bracket-acid inline-flex items-center justify-center gap-3 px-8 py-[18px] bg-acid text-ink font-bold uppercase tracking-tight hover:bg-acid/80 transition-colors duration-300 group"
+					>
+						Laten we kennismaken
+						<span class="text-xl leading-none transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
+					</a>
+				</div>
+			</div>
+		</div>
+	</main>
+	<Footer />
+</Layout>


### PR DESCRIPTION
## Summary
Complete navigation restructure to reflect solo entrepreneur positioning with clearer service-focused structure.

## New Navigation

```
Websites | Aanpak | Projecten | Kennis | Over Mij | Contact | [Stuur Bericht]
```

| Nav Item | Links To | Change |
|----------|----------|--------|
| Websites | `/website-laten-maken` | New |
| Aanpak | `/aanpak` | New page |
| Projecten | `/portfolio` | Renamed from "Portfolio" |
| Kennis | `/blog` | Renamed from "Blog" |
| Over Mij | `/over-mij` | New page |
| Contact | `/contact` | New |
| Stuur Bericht | `/contact` | Secondary CTA style |

## New Pages Created

### `/aanpak`
- Detailed 5-step process with timing estimates
- "What makes it different" section (Snel, Direct Contact, Geen Gedoe)
- CTA to booking

### `/over-mij`
- Personal bio section with photo placeholder
- "Waar Ik In Geloof" values section
- Quick stats (50+ websites, 7 days, 100% satisfied, 0 WordPress)
- Location info

## Design Changes
- CTA button changed from filled acid to outline style for cleaner appearance
- Removed "Prijzen" and "FAQ" from nav (still accessible via homepage)

## Test plan
- [ ] Verify all nav links work correctly
- [ ] Check new /aanpak page renders properly
- [ ] Check new /over-mij page renders properly
- [ ] Test mobile nav menu with new structure
- [ ] Verify secondary CTA button styling

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)