### PR TITLE
feat(footer): unified CTA section and remove bracket hover effect

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,8 +2,49 @@
 import TextRevealCSS from "./TextRevealCSS.astro";
 import { getAllCities } from "../data/cities";
 
+interface Props {
+	hideCTA?: boolean;
+	ctaHeadline?: string;
+	ctaSubtext?: string;
+}
+
+const {
+	hideCTA = false,
+	ctaHeadline = "Nog steeds alles zelf aan het regelen?",
+	ctaSubtext = "Ik denk graag mee. Stuur een bericht of plan een kort gesprek in.",
+} = Astro.props;
 const cities = getAllCities();
 ---
+
+{!hideCTA && (
+	<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-ink text-canvas bg-grid-dark relative overflow-hidden">
+		<div class="absolute inset-0 bg-grid-dark opacity-50"></div>
+		<div class="max-w-6xl xl:max-w-7xl mx-auto text-center relative z-10">
+			<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tighter leading-[0.95] mb-6">
+				{ctaHeadline}
+			</h2>
+			<p class="text-canvas/60 text-lg mb-10 max-w-xl mx-auto">
+				{ctaSubtext}
+			</p>
+			<div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+				<a
+					href="/aanvragen"
+					class="bg-acid text-ink px-8 py-[18px] font-bold uppercase tracking-tight hover:bg-acid/80 transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
+				>
+					Plan een gesprek in
+					<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
+				</a>
+				<a
+					href="/contact"
+					class="border border-canvas/30 text-canvas px-8 py-[18px] font-bold uppercase tracking-tight hover:bg-canvas/10 transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
+				>
+					Neem contact op
+					<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
+				</a>
+			</div>
+		</div>
+	</section>
+)}
 
 <footer class="bg-ink text-canvas py-12 md:py-16 px-6 md:px-12 lg:px-16 bg-grid-dark relative overflow-hidden">
 	<div class="max-w-6xl xl:max-w-7xl mx-auto relative z-10">

--- a/src/components/OfferSection.astro
+++ b/src/components/OfferSection.astro
@@ -68,7 +68,7 @@
 
 				<a
 					href="/aanvragen"
-					class="btn-bracket btn-bracket-ink w-full bg-ink/5 text-ink py-3 font-bold uppercase tracking-tight text-sm hover:bg-ink hover:text-canvas transition-colors duration-300 text-center"
+					class="w-full bg-ink/5 text-ink py-3 font-bold uppercase tracking-tight text-sm hover:bg-ink hover:text-canvas transition-colors duration-300 text-center"
 				>
 					Kies Start
 				</a>
@@ -126,7 +126,7 @@
 
 				<a
 					href="/aanvragen"
-					class="btn-bracket btn-bracket-ink w-full bg-ink text-acid py-3 font-bold uppercase tracking-tight text-sm hover:bg-ink/80 transition-colors duration-300 text-center"
+					class="w-full bg-ink text-acid py-3 font-bold uppercase tracking-tight text-sm hover:bg-ink/80 transition-colors duration-300 text-center"
 				>
 					Kies Slim
 				</a>
@@ -179,7 +179,7 @@
 
 				<a
 					href="/aanvragen"
-					class="btn-bracket btn-bracket-acid w-full bg-acid text-ink py-3 font-bold uppercase tracking-tight text-sm hover:bg-acid/80 transition-colors duration-300 text-center"
+					class="w-full bg-acid text-ink py-3 font-bold uppercase tracking-tight text-sm hover:bg-acid/80 transition-colors duration-300 text-center"
 				>
 					Kies Systeem
 				</a>

--- a/src/components/PortfolioSection.astro
+++ b/src/components/PortfolioSection.astro
@@ -66,7 +66,7 @@ const featured = getShowcaseProject();
 							href={featured.link}
 							target="_blank"
 							rel="noopener noreferrer"
-							class="btn-bracket btn-bracket-acid w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-acid/80 transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
+							class="w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-acid/80 transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 						>
 							<span>Bekijk Live</span>
 							<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>

--- a/src/pages/aanpak.astro
+++ b/src/pages/aanpak.astro
@@ -123,25 +123,6 @@ const steps = [
 				</div>
 			</div>
 
-			<!-- CTA Section -->
-			<div class="p-8 md:p-12 bg-ink text-canvas relative overflow-hidden">
-				<div class="absolute inset-0 bg-grid-dark opacity-50"></div>
-				<div class="relative z-10 text-center">
-					<h2 class="text-2xl md:text-4xl font-black uppercase tracking-tighter mb-4">
-						Klinkt Goed?
-					</h2>
-					<p class="text-canvas/60 text-lg mb-8 max-w-xl mx-auto">
-						Laten we kennismaken. Een kort gesprek van 20 minuten, vrijblijvend.
-					</p>
-					<a
-						href="/aanvragen"
-						class="btn-bracket btn-bracket-acid inline-flex items-center justify-center gap-3 px-8 py-[18px] bg-acid text-ink font-bold uppercase tracking-tight hover:bg-acid/80 transition-colors duration-300 group"
-					>
-						Laten we kennismaken
-						<span class="text-xl leading-none transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
-					</a>
-				</div>
-			</div>
 		</div>
 	</main>
 	<Footer />

--- a/src/pages/aanvragen.astro
+++ b/src/pages/aanvragen.astro
@@ -283,7 +283,7 @@ import Footer from "../components/Footer.astro";
                     <button
                         type="submit"
                         id="submit-btn"
-                        class="btn-bracket btn-bracket-ink w-full md:w-auto px-8 py-5 bg-acid text-ink font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                        class="w-full md:w-auto px-8 py-5 bg-acid text-ink font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                         <span id="btn-text">Laten we kennismaken</span>
                         <span id="btn-arrow" class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
@@ -330,7 +330,7 @@ import Footer from "../components/Footer.astro";
 
         </div>
     </main>
-    <Footer />
+    <Footer hideCTA />
 </Layout>
 
 <script>

--- a/src/pages/aanvragen/bedankt.astro
+++ b/src/pages/aanvragen/bedankt.astro
@@ -45,5 +45,5 @@ import Footer from "../../components/Footer.astro";
             </div>
         </div>
     </main>
-    <Footer />
+    <Footer hideCTA />
 </Layout>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -124,41 +124,23 @@ const breadcrumbs = [
 			</div>
 		</section>
 
-		<!-- Author / CTA Section -->
+		<!-- Author Section -->
 		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light">
 			<div class="max-w-3xl mx-auto">
-				<!-- Author Box -->
-				<div class="border border-ink/10 p-8 mb-12">
+				<div class="border border-ink/10 p-8">
 					<div class="flex items-start gap-4">
-						<div class="w-12 h-12 bg-acid flex items-center justify-center flex-shrink-0">
-							<span class="text-ink font-black text-lg">KG</span>
-						</div>
+						<img
+							src="/assets/yannick.jpeg"
+							alt="Yannick"
+							class="w-12 h-12 rounded-full object-cover object-top flex-shrink-0"
+						/>
 						<div>
 							<p class="font-bold text-lg mb-1">{post.data.author}</p>
 							<p class="text-ink/60 text-sm leading-relaxed">
-								Webdesign bureau uit Buren. Wij maken professionele websites voor ondernemers
-								in 7 dagen voor €595. Geen gedoe, wél resultaat.
+								Ik bouw slimme websites voor ondernemers. Snel, zonder gedoe, met automatisering die voor je werkt.
 							</p>
 						</div>
 					</div>
-				</div>
-
-				<!-- CTA -->
-				<div class="text-center">
-					<h2 class="text-2xl md:text-3xl font-black uppercase tracking-tighter mb-4">
-						Hulp Nodig Bij Je Website?
-					</h2>
-					<p class="text-ink/60 mb-6 max-w-lg mx-auto">
-						Wil je weten wat ik voor jouw bedrijf kan betekenen?
-						Laten we even sparren over de mogelijkheden.
-					</p>
-					<a
-						href="/aanvragen"
-						class="btn-bracket btn-bracket-ink bg-acid text-ink px-8 py-4 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
-					>
-						Laten we kennismaken
-						<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
-					</a>
 				</div>
 			</div>
 		</section>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -100,26 +100,6 @@ const breadcrumbs = [
 			</div>
 		</section>
 
-		<!-- CTA Section -->
-		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light">
-			<div class="max-w-6xl xl:max-w-7xl mx-auto text-center">
-				<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tighter leading-[0.95] mb-6">
-					Klaar Voor Je Eigen Website?
-				</h2>
-				<p class="text-xl text-ink/60 max-w-2xl mx-auto mb-8">
-					Na al dat lezen ben je misschien wel klaar om de stap te zetten.
-					Laten we even sparren over wat ik voor jouw bedrijf kan betekenen.
-				</p>
-				<a
-					href="/aanvragen"
-					class="btn-bracket btn-bracket-ink bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
-				>
-					Laten we kennismaken
-					<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
-				</a>
-			</div>
-		</section>
-
 		<Footer />
 	</main>
 </Layout>

--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -134,7 +134,7 @@ const breadcrumbs = [
 				</p>
 				<a
 					href="/aanvragen"
-					class="btn-bracket btn-bracket-ink bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
+					class="bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 				>
 					Laten we kennismaken
 					<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -164,7 +164,7 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 						<button
 							type="submit"
 							id="submit-btn"
-							class="btn-bracket btn-bracket-ink bg-acid text-ink px-8 py-4 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center gap-3 group cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+							class="bg-acid text-ink px-8 py-4 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center gap-3 group cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
 						>
 							<span id="btn-text">Verstuur bericht</span>
 							<span id="btn-arrow" class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
@@ -203,7 +203,7 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 								</p>
 								<a
 									href="/aanvragen"
-									class="btn-bracket btn-bracket-acid inline-flex items-center justify-center gap-3 px-6 py-3 bg-acid text-ink font-bold uppercase tracking-tight text-sm hover:bg-acid/80 transition-colors duration-300 group w-full"
+									class="inline-flex items-center justify-center gap-3 px-6 py-3 bg-acid text-ink font-bold uppercase tracking-tight text-sm hover:bg-acid/80 transition-colors duration-300 group w-full"
 								>
 									Plan een gesprek in
 									<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
@@ -305,7 +305,7 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 			</div>
 		</div>
 	</main>
-	<Footer />
+	<Footer hideCTA />
 </Layout>
 
 <script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -59,7 +59,7 @@ const cities = getAllCities();
 				<!-- CTA -->
 				<a
 					href="/aanvragen"
-					class="btn-bracket btn-bracket-ink w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group mb-12 md:mb-16"
+					class="w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group mb-12 md:mb-16"
 				>
 				Laten we kennismaken
 					<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
@@ -287,20 +287,7 @@ const cities = getAllCities();
 					</div>
 				</div>
 
-				<!-- Final CTA -->
-				<div class="mt-16 pt-12 border-t border-ink/10 text-center">
-					<p class="text-xl md:text-2xl font-bold mb-6">
-						Klaar om te beginnen?
-					</p>
-					<a
-						href="/aanvragen"
-						class="btn-bracket btn-bracket-ink bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
-					>
-					Laten we kennismaken
-						<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
-					</a>
 				</div>
-			</div>
 		</section>
 
 		<Footer />

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -172,34 +172,6 @@ const breadcrumbs = [
                 })}
             </div>
 
-            <!-- End of Timeline -->
-            <div class="max-w-6xl xl:max-w-7xl mx-auto px-6 md:px-12 lg:px-16 mt-24 md:mt-32">
-                <div class="relative">
-                    <!-- Final Node -->
-                    <div class="absolute left-1/2 -top-12 -translate-x-1/2 hidden md:flex flex-col items-center">
-                        <div class="w-px h-12 bg-gradient-to-b from-acid/30 to-acid"></div>
-                        <div class="w-4 h-4 bg-acid rotate-45"></div>
-                    </div>
-
-                    <!-- CTA Card -->
-                    <div class="bg-acid p-8 md:p-12 text-center">
-                        <h3 class="text-2xl md:text-4xl font-black uppercase tracking-tight text-ink mb-4">
-                            Jouw Project Hier?
-                        </h3>
-                        <p class="text-ink/70 max-w-xl mx-auto mb-8">
-                            We werken continu aan nieuwe concept websites voor lokale ondernemers.
-                            Wil jij de volgende zijn op deze pagina?
-                        </p>
-                        <a
-                            href="/aanvragen"
-                            class="btn-bracket btn-bracket-ink w-full sm:w-auto bg-ink text-acid px-8 py-4 font-bold uppercase tracking-tight hover:bg-ink/80 transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
-                        >
-                            Laten we kennismaken
-                            <span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
-                        </a>
-                    </div>
-                </div>
-            </div>
         </section>
 
         <Footer />

--- a/src/pages/project/[slug].astro
+++ b/src/pages/project/[slug].astro
@@ -72,7 +72,7 @@ const pageTitle = `${project.title} | Website ${project.industry} Voorbeeld`;
 								href={project.link}
 								target="_blank"
 								rel="noopener noreferrer"
-								class="btn-bracket btn-bracket-ink w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
+								class="w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 							>
 								<span>Bekijk Live</span>
 								<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
@@ -212,7 +212,7 @@ const pageTitle = `${project.title} | Website ${project.industry} Voorbeeld`;
 							</p>
 							<a
 								href="/aanvragen"
-								class="btn-bracket btn-bracket-ink w-full sm:w-auto bg-ink text-acid px-8 py-4 font-bold uppercase tracking-tight hover:bg-ink/80 transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
+								class="w-full sm:w-auto bg-ink text-acid px-8 py-4 font-bold uppercase tracking-tight hover:bg-ink/80 transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 							>
 								<span>Start Jouw Project</span>
 							</a>
@@ -236,7 +236,7 @@ const pageTitle = `${project.title} | Website ${project.industry} Voorbeeld`;
 				</div>
 				<a
 					href="/portfolio"
-					class="btn-bracket btn-bracket-acid w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-acid/80 transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
+					class="w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-acid/80 transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 				>
 					<span>Naar Portfolio</span>
 					<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>

--- a/src/pages/webdesign-[city].astro
+++ b/src/pages/webdesign-[city].astro
@@ -79,7 +79,7 @@ const breadcrumbs = [
                         </p>
                         <a
                             href="/aanvragen"
-                            class="btn-bracket btn-bracket-ink w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
+                            class="w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
                         >
                             Laten we kennismaken
                             <span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>

--- a/src/pages/website-laten-maken.astro
+++ b/src/pages/website-laten-maken.astro
@@ -64,7 +64,7 @@ const faqs = [
 
 				<a
 					href="/aanvragen"
-					class="btn-bracket btn-bracket-ink w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group mb-12 md:mb-16"
+					class="w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group mb-12 md:mb-16"
 				>
 					Laten we kennismaken
 					<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
@@ -207,7 +207,7 @@ const faqs = [
 				<div class="mt-12 pt-8 border-t border-ink/10">
 					<a
 						href="/aanvragen"
-						class="btn-bracket btn-bracket-ink bg-ink text-canvas px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink/80 transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
+						class="bg-ink text-canvas px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink/80 transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 					>
 						Laten we kennismaken
 						<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
@@ -326,26 +326,9 @@ const faqs = [
 			</div>
 		</section>
 
-		<!-- FINAL CTA -->
-		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-ink text-canvas bg-grid-dark relative overflow-hidden">
-			<div class="max-w-6xl xl:max-w-7xl mx-auto text-center">
-				<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tighter leading-[0.95] mb-6">
-					Klaar Om Te Beginnen?
-				</h2>
-				<p class="text-canvas/70 text-lg mb-10 max-w-xl mx-auto">
-					Laten we even sparren. 15 minuten, geen verplichtingen.
-					Je kiest zelf een moment dat jou uitkomt.
-				</p>
-				<a
-					href="/aanvragen"
-					class="btn-bracket btn-bracket-acid bg-acid text-ink px-10 py-6 font-bold uppercase tracking-tight text-xl hover:bg-acid/80 transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
-				>
-					Laten we kennismaken
-					<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
-				</a>
-			</div>
-		</section>
-
-		<Footer />
+		<Footer
+			ctaHeadline="Toe aan een nieuwe website?"
+			ctaSubtext="Laten we even sparren over wat jouw bedrijf nodig heeft."
+		/>
 	</main>
 </Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -97,64 +97,6 @@
   transform: scaleX(1);
 }
 
-/* ========================================
-   Button Bracket Hover Effect
-   Corner brackets that expand to full border
-   Inspired by [ bracket ] design language
-   ======================================== */
-
-.btn-bracket {
-  position: relative;
-  overflow: visible;
-  z-index: 1;
-}
-
-/* Top-left and bottom-right corners */
-.btn-bracket::before,
-.btn-bracket::after {
-  content: '';
-  position: absolute;
-  width: 12px;
-  height: 12px;
-  transition: all 0.4s cubic-bezier(0.25, 1, 0.5, 1);
-  pointer-events: none;
-  z-index: 10;
-}
-
-.btn-bracket::before {
-  top: -3px;
-  left: -3px;
-  border-top: 2px solid var(--bracket-color, var(--color-ink));
-  border-left: 2px solid var(--bracket-color, var(--color-ink));
-}
-
-.btn-bracket::after {
-  bottom: -3px;
-  right: -3px;
-  border-bottom: 2px solid var(--bracket-color, var(--color-ink));
-  border-right: 2px solid var(--bracket-color, var(--color-ink));
-}
-
-/* Expand to full border on hover */
-.btn-bracket:hover::before,
-.btn-bracket:hover::after {
-  width: calc(100% + 6px);
-  height: calc(100% + 6px);
-}
-
-/* Color variants */
-.btn-bracket-acid {
-  --bracket-color: var(--color-acid);
-}
-
-.btn-bracket-ink {
-  --bracket-color: var(--color-ink);
-}
-
-.btn-bracket-canvas {
-  --bracket-color: var(--color-canvas);
-}
-
 /* Reusable grid backgrounds */
 .bg-grid-light {
   background-image:


### PR DESCRIPTION
## Summary
- Add unified CTA section to Footer component with dual buttons ("Plan een gesprek in" + "Neem contact op")
- Configurable `ctaHeadline` and `ctaSubtext` props with problem-focused defaults
- Website page gets custom CTA: "Toe aan een nieuwe website?"
- Hidden on contact, aanvragen, and bedankt pages via `hideCTA` prop
- Remove all per-page CTA sections from 6 pages
- Remove `btn-bracket` hover effect site-wide (CSS + 15 class references)
- Update blog author box with profile photo and solo entrepreneur copy

Closes #149

## Test plan
- [ ] Verify unified CTA appears on all pages except contact/aanvragen/bedankt
- [ ] Check website-laten-maken page shows custom headline
- [ ] Verify no bracket hover animation on any button
- [ ] Test dual buttons link correctly (/aanvragen + /contact)
- [ ] Check mobile responsive layout of CTA buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)