### PR TITLE
feat(services): rebuild website-laten-maken as detailed service page ✨ (#151)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,6 @@
 export const prerender = true;
 
 import Layout from "../layouts/Layout.astro";
-import OfferSection from "../components/OfferSection.astro";
 import PortfolioSection from "../components/PortfolioSection.astro";
 import ProcessSection from "../components/ProcessSection.astro";
 import Footer from "../components/Footer.astro";
@@ -102,18 +101,18 @@ const cities = getAllCities();
 					<div class="space-y-6 text-canvas/80 text-lg leading-relaxed">
 						<p>
 							Waarom zou een loodgieter uit Tiel een minder mooie website hebben dan een multinational?
-							Goede vraag. Dat zou niet moeten. Bij KNAP GEMAAKT. bouwen we premium websites
+							Goede vraag. Dat zou niet moeten. Bij KNAP GEMAAKT. bouw ik premium websites
 							waarmee lokale ondernemers kunnen concurreren met de grote jongens. Razendsnel,
 							professioneel, en zonder de prijs van een kleine auto.
 						</p>
 						<p>
 							Elk ontwerp is uniek en wordt vanaf nul gebouwd. Geen templates, geen themes
-							die je op duizend andere sites terugziet. Website nodig? €595, klaar in 7 dagen.
-							Webshop? €1795, klaar in 2 tot 3 weken. Inclusief design, teksten, hosting. De hele santenkraam.
+							die je op duizend andere sites terugziet. Website nodig? Vanaf €495, klaar in 7 dagen.
+							Slimmer systeem met automations? €995. Inclusief design, teksten, hosting. De hele santenkraam.
 						</p>
 						<p>
-							En ja, we schrijven ook je teksten. Want laten we eerlijk zijn: jij bent goed in je vak,
-							niet in het staren naar een leeg Word-document om 23:00. Wij regelen het. Jij onderneemt.
+							En ja, ik schrijf ook je teksten. Want laten we eerlijk zijn: jij bent goed in je vak,
+							niet in het staren naar een leeg Word-document om 23:00. Ik regel het. Jij onderneemt.
 						</p>
 					</div>
 				</div>
@@ -128,9 +127,42 @@ const cities = getAllCities();
 		<!-- PROCESS SECTION -->
 		<ProcessSection />
 
-		<!-- OFFER/PRICING SECTION -->
-		<section id="prijzen">
-			<OfferSection />
+		<!-- PRICING CTA -->
+		<section id="prijzen" class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light relative overflow-hidden">
+			<div class="max-w-6xl xl:max-w-7xl mx-auto">
+				<div class="grid md:grid-cols-2 gap-8 md:gap-12 items-center">
+					<div>
+						<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-6">
+							[ Onze Pakketten ]
+						</div>
+						<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tighter leading-[0.95] mb-6">
+							Vanaf €495.
+						</h2>
+						<p class="text-ink/70 text-lg leading-relaxed mb-8">
+							Een professionele website voor €495. Of een slim systeem dat afspraken boekt, reviews verzamelt en leads opvolgt voor €995. Vaste prijs, geen verrassingen.
+						</p>
+						<a
+							href="/website-laten-maken"
+							class="bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
+						>
+							Bekijk pakketten
+							<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
+						</a>
+					</div>
+					<div class="grid grid-cols-2 gap-4">
+						<div class="p-6 border-2 border-ink/10 bg-canvas">
+							<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-3">Website</div>
+							<div class="text-3xl font-black mb-2">€495</div>
+							<p class="text-ink/60 text-sm">Professioneel online in 7 dagen</p>
+						</div>
+						<div class="p-6 border-2 border-acid bg-acid">
+							<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-3">Systeem</div>
+							<div class="text-3xl font-black mb-2">€995</div>
+							<p class="text-ink/70 text-sm">Je digitale medewerker</p>
+						</div>
+					</div>
+				</div>
+			</div>
 		</section>
 
 		<!-- WHY CHOOSE US SECTION (More SEO Content) -->
@@ -140,10 +172,10 @@ const cities = getAllCities();
 					[ Waarom KNAP GEMAAKT. ]
 				</div>
 				<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tighter leading-[0.95] mb-6 max-w-3xl">
-					Waarom Ondernemers Voor Ons Kiezen.
+					Waarom Ondernemers Mij Kiezen.
 				</h2>
 				<p class="text-ink/60 text-lg mb-12 md:mb-16 max-w-2xl">
-					Simpel: wij bouwen sneller, rekenen minder, en leveren kwaliteit. Dat is het eigenlijk.
+					Simpel: ik bouw sneller, reken minder en lever kwaliteit. Dat is het eigenlijk.
 				</p>
 
 				<div class="grid md:grid-cols-3 gap-8 md:gap-12">
@@ -152,7 +184,7 @@ const cities = getAllCities();
 						<h3 class="text-xl font-black uppercase tracking-tight">Enterprise Kwaliteit</h3>
 						<p class="text-ink/70 leading-relaxed">
 							Dezelfde technologie die grote bedrijven gebruiken. Razendsnel, veilig, perfect vindbaar in Google.
-							Het verschil? Wij rekenen geen enterprise-prijzen. Jouw website presteert als die van de grote jongens,
+							Het verschil? Ik reken geen enterprise-prijzen. Jouw website presteert als die van de grote jongens,
 							zonder het prijskaartje.
 						</p>
 					</div>
@@ -161,9 +193,8 @@ const cities = getAllCities();
 						<div class="text-electric font-mono text-sm">[02]</div>
 						<h3 class="text-xl font-black uppercase tracking-tight">Geen Gedoe</h3>
 						<p class="text-ink/70 leading-relaxed">
-							Eén gesprek van 15 minuten. Wij doen de rest. Geen eindeloze vergaderingen, geen feedback-rondes
+							Eén gesprek van 15 minuten. Ik doe de rest. Geen eindeloze vergaderingen, geen feedback-rondes
 							die maanden duren, geen "kun je de teksten aanleveren?" Binnen 7 dagen staat je site live.
-							Webshop? 2 tot 3 weken.
 						</p>
 					</div>
 
@@ -171,9 +202,9 @@ const cities = getAllCities();
 						<div class="text-electric font-mono text-sm">[03]</div>
 						<h3 class="text-xl font-black uppercase tracking-tight">Eerlijke Prijzen</h3>
 						<p class="text-ink/70 leading-relaxed">
-							€595 voor een website. €1795 voor een webshop. Dat is het. Geen offerte die oploopt,
+							€495 voor een website. €995 voor een slim systeem. Dat is het. Geen offerte die oploopt,
 							geen verborgen kosten, geen "dit valt buiten scope." Je weet vooraf wat je betaalt.
-							Traditionele bureaus vragen €2.000 tot €5.000 voor hetzelfde. Wij niet.
+							Traditionele bureaus vragen €2.000 tot €5.000 voor hetzelfde. Ik niet.
 						</p>
 					</div>
 				</div>
@@ -190,8 +221,8 @@ const cities = getAllCities();
 					Webdesign in Heel Nederland
 				</h2>
 				<p class="text-canvas/70 text-lg leading-relaxed max-w-2xl mb-12">
-					Vanuit Buren bedienen we ondernemers door heel Nederland. Of je nu in Utrecht zit
-					of in een klein dorp in de Betuwe, wij bouwen jouw website. Bekijk onze lokale pagina's
+					Vanuit Buren bedien ik ondernemers door heel Nederland. Of je nu in Utrecht zit
+					of in een klein dorp in de Betuwe, ik bouw jouw website. Bekijk de lokale pagina's
 					voor meer informatie over webdesign in jouw regio.
 				</p>
 
@@ -212,8 +243,8 @@ const cities = getAllCities();
 				</div>
 
 				<p class="text-canvas/50 text-sm mt-8 font-mono">
-					Staat jouw regio er niet bij? Geen probleem, we werken voor ondernemers in heel Nederland.
-					<a href="/aanvragen" class="text-acid hover:underline">Neem contact op</a> en we helpen je verder.
+					Staat jouw regio er niet bij? Geen probleem, ik werk voor ondernemers in heel Nederland.
+					<a href="/aanvragen" class="text-acid hover:underline">Neem contact op</a> en ik help je verder.
 				</p>
 			</div>
 		</section>
@@ -234,25 +265,25 @@ const cities = getAllCities();
 							<h3 class="text-lg font-bold text-electric">Hoe werkt het proces?</h3>
 							<p class="text-ink/70 leading-relaxed">
 								Simpel. We bellen 15 minuten over je bedrijf en wat je wilt bereiken.
-								Daarna gaan wij aan de slag. Binnen 7 dagen krijg je het ontwerp te zien.
-								Feedback? We passen aan. Dan gaat je site live. Klaar.
+								Daarna ga ik aan de slag. Binnen 7 dagen krijg je het ontwerp te zien.
+								Feedback? Ik pas aan. Dan gaat je site live. Klaar.
 							</p>
 						</div>
 
 						<div class="space-y-3">
 							<h3 class="text-lg font-bold text-electric">Wat als ik niet tevreden ben?</h3>
 							<p class="text-ink/70 leading-relaxed">
-								Geld terug. Serieus. Wij hebben een 100% tevredenheidsgarantie.
+								Geld terug. Serieus. Ik heb een 100% tevredenheidsgarantie.
 								Vind je het niks? Dan krijg je je geld terug. Geen discussie, geen gedoe.
-								We willen alleen tevreden klanten. Ontevreden klanten zijn slecht voor ons humeur.
+								Ik wil alleen tevreden klanten.
 							</p>
 						</div>
 
 						<div class="space-y-3">
 							<h3 class="text-lg font-bold text-electric">Moet ik zelf teksten aanleveren?</h3>
 							<p class="text-ink/70 leading-relaxed">
-								Nee. Wij schrijven alles voor je. We duiken in je branche, bekijken je concurrenten,
-								en schrijven teksten die je klanten aanspreken. Jij hoeft alleen te checken of het klopt.
+								Nee. Ik schrijf alles voor je. Ik duik in je branche, bekijk je concurrenten
+								en schrijf teksten die je klanten aanspreken. Jij hoeft alleen te checken of het klopt.
 								Liever eigen teksten? Prima, jij beslist.
 							</p>
 						</div>
@@ -260,11 +291,10 @@ const cities = getAllCities();
 
 					<div class="space-y-8">
 						<div class="space-y-3">
-							<h3 class="text-lg font-bold text-electric">Bouwen jullie ook webshops?</h3>
+							<h3 class="text-lg font-bold text-electric">Wat is het verschil tussen Website en Systeem?</h3>
 							<p class="text-ink/70 leading-relaxed">
-								Ja. €1795, klaar in 2 tot 3 weken. Complete webshop met productbeheer,
-								winkelwagen, iDEAL, creditcard, het hele pakket.
-								Heb je een simpele website nodig die later een webshop wordt? Kan ook. We denken met je mee.
+								Een Website (€495) is een professionele online aanwezigheid. Een Systeem (€995) doet meer:
+								afspraken boeken, reviews verzamelen, leads opvolgen. Start simpel en bouw later uit als je wilt.
 							</p>
 						</div>
 
@@ -272,16 +302,16 @@ const cities = getAllCities();
 							<h3 class="text-lg font-bold text-electric">Is het beheerpakket verplicht?</h3>
 							<p class="text-ink/70 leading-relaxed">
 								Nee. Je website werkt prima zonder. Hosting zit altijd inbegrepen.
-								Het beheerpakket (€49/maand) is voor als je niet wilt nadenken over je website:
-								wij doen updates, kleine aanpassingen, backups. Jij appt wat je wilt, wij regelen het.
+								Het beheerpakket (vanaf €28,30/maand) is voor als je niet wilt nadenken over je website:
+								ik doe updates, kleine aanpassingen, monitoring. Jij appt wat je wilt, ik regel het.
 							</p>
 						</div>
 
 						<div class="space-y-3">
-							<h3 class="text-lg font-bold text-electric">Werken jullie door heel Nederland?</h3>
+							<h3 class="text-lg font-bold text-electric">Werk je door heel Nederland?</h3>
 							<p class="text-ink/70 leading-relaxed">
 								Ja. Amsterdam, Maastricht, Groningen, maakt niet uit. Alles gaat digitaal.
-								We bellen, mailen, appen. Je hoeft nergens naartoe. Scheelt jou tijd, scheelt ons koffie.
+								Bellen, mailen, appen. Je hoeft nergens naartoe. Scheelt jou tijd, scheelt mij koffie.
 							</p>
 						</div>
 					</div>

--- a/src/pages/webdesign-[city].astro
+++ b/src/pages/webdesign-[city].astro
@@ -1,6 +1,5 @@
 ---
 import Layout from "../layouts/Layout.astro";
-import OfferSection from "../components/OfferSection.astro";
 import PortfolioSection from "../components/PortfolioSection.astro";
 import LocalSEOSection from "../components/LocalSEOSection.astro";
 import Footer from "../components/Footer.astro";
@@ -122,9 +121,6 @@ const breadcrumbs = [
 
         <!-- Portfolio -->
         <PortfolioSection />
-
-        <!-- Pricing & Offer -->
-        <OfferSection />
 
         <!-- Footer -->
         <Footer />

--- a/src/pages/website-laten-maken.astro
+++ b/src/pages/website-laten-maken.astro
@@ -6,43 +6,54 @@ import Footer from "../components/Footer.astro";
 import TextRevealCSS from "../components/TextRevealCSS.astro";
 import LocalBusinessSchema from "../components/seo/LocalBusinessSchema.astro";
 import FAQSchema from "../components/seo/FAQSchema.astro";
+import BreadcrumbSchema from "../components/seo/BreadcrumbSchema.astro";
+
+const breadcrumbs = [
+	{ name: "Home", url: "https://knapgemaakt.nl/" },
+	{ name: "Website Laten Maken", url: "https://knapgemaakt.nl/website-laten-maken" },
+];
 
 const faqs = [
 	{
-		question: "Wat kost een website laten maken bij KNAP GEMAAKT.?",
-		answer: "€595 vast. Dat is inclusief design, teksten, hosting, en SEO-basis. Geen verborgen kosten, geen offertes die oplopen. Je weet vooraf wat je betaalt.",
+		question: "Wat kost een website laten maken?",
+		answer: "Vanaf €495 voor een professionele website inclusief design, teksten en hosting. Wil je daar slimme automations bij, zoals een afsprakenplanner of automatische review-verzoeken? Dan is het €995. Vaste prijzen, geen verrassingen achteraf.",
 	},
 	{
-		question: "Hoe lang duurt het om een website te laten maken?",
-		answer: "7 dagen. Na een kort kennismakingsgesprek van 15 minuten gaan wij aan de slag. Binnen een week staat je website live.",
+		question: "Hoe lang duurt het?",
+		answer: "Een website is klaar in 7 dagen. Een systeem met automations duurt 2 tot 3 weken, afhankelijk van wat er nodig is. Na een kort kennismakingsgesprek van 15 minuten gaan we aan de slag.",
 	},
 	{
-		question: "Moet ik zelf teksten en foto's aanleveren?",
-		answer: "Teksten schrijven wij. Foto's zijn wel handig als je ze hebt, want eigen beelden maken je website persoonlijker dan stockfoto's. Heb je niks? Dan regelen wij het.",
+		question: "Moet ik zelf teksten aanleveren?",
+		answer: "Dat hoeft niet. Ik duik in je branche, bekijk je concurrenten en schrijf teksten die je klanten aanspreken. Heb je liever eigen teksten? Ook prima, dan werken we daarmee.",
 	},
 	{
-		question: "Kan ik later aanpassingen laten doen?",
-		answer: "Ja. Kleine wijzigingen zitten in ons beheerpakket (€49/maand). Grotere aanpassingen? Daar maken we een losse offerte voor.",
+		question: "Wat als ik later automations wil toevoegen?",
+		answer: "Kan altijd. Je kunt beginnen met een website, en als je later merkt dat je een afsprakenplanner of automatische review-verzoeken nodig hebt, bouwen we dat erbij. Je hoeft niet alles in één keer te beslissen.",
 	},
 	{
-		question: "Wat als ik niet tevreden ben met het resultaat?",
-		answer: "Geld terug. We hebben een 100% tevredenheidsgarantie. Vind je het niks? Dan krijg je je geld terug. Geen discussie.",
+		question: "Ben ik gebonden aan een contract?",
+		answer: "Nee. Je website draait op jouw Cloudflare-account en de broncode is openbaar op GitHub. Stop je met het maandelijks beheer? Je site blijft gewoon online. Geen lock-in, geen gedoe.",
+	},
+	{
+		question: "Wat als ik niet tevreden ben?",
+		answer: "Dan krijg je je geld terug. Ik heb een 100% tevredenheidsgarantie. Vind je het niks? Geld terug. Geen discussie.",
 	},
 ];
 ---
 
 <Layout
-	title="Website Laten Maken | €595 Vast | 7 Dagen Live | KNAP GEMAAKT."
-	description="Website laten maken die voor je werkt? Een slimme website die klanten boekt en leads vangt. €595 vast, binnen 7 dagen live."
+	title="Website Laten Maken €495 | 7 Dagen | KNAP GEMAAKT."
+	description="Professionele website op maat laten maken vanaf €495. ✓ Klaar in 7 dagen ✓ Design & teksten inbegrepen ✓ Tevredenheidsgarantie. Vraag nu aan!"
 >
 	<LocalBusinessSchema />
 	<FAQSchema faqs={faqs} />
+	<BreadcrumbSchema items={breadcrumbs} />
 
 	<main class="bg-canvas">
 		<!-- HERO SECTION -->
 		<section class="min-h-[80vh] flex flex-col justify-center relative overflow-hidden px-6 md:px-12 lg:px-16 py-24 bg-grid-light">
-			<div class="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,rgba(204,255,0,0.04),transparent_50%)] pointer-events-none"></div>
-			<div class="absolute top-1/4 -right-1/4 w-[600px] h-[600px] bg-acid/5 rounded-full blur-[120px] pointer-events-none"></div>
+			<div class="hidden md:block absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,rgba(204,255,0,0.04),transparent_50%)] pointer-events-none"></div>
+			<div class="hidden md:block absolute top-1/4 -right-1/4 w-[600px] h-[600px] bg-acid/5 rounded-full blur-[120px] pointer-events-none"></div>
 
 			<div class="max-w-6xl xl:max-w-7xl mx-auto w-full relative z-10">
 				<h1 class="mb-6 md:mb-8">
@@ -58,8 +69,12 @@ const faqs = [
 					/>
 				</h1>
 
-				<p class="text-lg md:text-xl lg:text-2xl text-ink/70 max-w-2xl mb-10 md:mb-12 leading-relaxed">
-					Niet zomaar een website. Een digitale medewerker die klanten boekt, leads vangt en reviews verzamelt. €595, binnen 7 dagen live.
+				<p class="text-lg md:text-xl lg:text-2xl text-ink/70 max-w-2xl mb-6 md:mb-8 leading-relaxed">
+					Een slimme website die reviews verzamelt, afspraken boekt en leads opvolgt. Terwijl jij onderneemt.
+				</p>
+				<p class="text-base md:text-lg text-ink/50 max-w-2xl mb-10 md:mb-12 leading-relaxed">
+					Een website op maat laten maken voor een vaste prijs. Vanaf €495 voor een maatwerk website,
+					of €995 voor een slim systeem met automations. Klaar in 7 dagen, inclusief design, teksten en hosting.
 				</p>
 
 				<a
@@ -73,7 +88,7 @@ const faqs = [
 				<div class="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-6 pt-8 border-t border-ink/10">
 					<div class="flex items-center gap-2 text-sm md:text-base text-ink/70">
 						<span class="w-2 h-2 bg-acid rounded-full shrink-0"></span>
-						<span>Werkt 24/7 voor je</span>
+						<span>Kant-en-klaar opgeleverd</span>
 					</div>
 					<div class="flex items-center gap-2 text-sm md:text-base text-ink/70">
 						<span class="w-2 h-2 bg-acid rounded-full shrink-0"></span>
@@ -81,7 +96,7 @@ const faqs = [
 					</div>
 					<div class="flex items-center gap-2 text-sm md:text-base text-ink/70">
 						<span class="w-2 h-2 bg-acid rounded-full shrink-0"></span>
-						<span>€595 vast</span>
+						<span>Jouw eigendom</span>
 					</div>
 					<div class="flex items-center gap-2 text-sm md:text-base text-ink/70">
 						<span class="w-2 h-2 bg-acid rounded-full shrink-0"></span>
@@ -91,234 +106,580 @@ const faqs = [
 			</div>
 		</section>
 
-		<!-- WHAT'S INCLUDED SECTION -->
+		<!-- WHAT YOU GET -->
 		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-ink text-canvas bg-grid-dark relative overflow-hidden">
 			<div class="max-w-6xl xl:max-w-7xl mx-auto">
 				<div class="text-xs font-mono uppercase tracking-[0.2em] text-acid mb-6">
 					[ Wat Je Krijgt ]
 				</div>
-				<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tighter leading-[0.95] mb-12 md:mb-16 max-w-3xl">
-					Alles Wat Je Nodig Hebt. Zonder Gedoe.
+				<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tighter leading-[0.95] mb-6 max-w-3xl">
+					Meer Dan Een Website.
 				</h2>
+				<p class="text-canvas/70 text-lg mb-12 md:mb-16 max-w-2xl leading-relaxed">
+					Elke website die ik bouw is maatwerk. Geen templates, geen themes die je overal terugziet.
+					Design, teksten, techniek. Ik regel het. Jij hoeft alleen te vertellen wat je doet.
+				</p>
 
 				<div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8 md:gap-10">
 					<div class="space-y-4">
 						<div class="text-acid font-mono text-sm">[01]</div>
 						<h3 class="text-xl font-black uppercase tracking-tight">Uniek Design</h3>
 						<p class="text-canvas/70 leading-relaxed">
-							Geen templates. Elk ontwerp wordt vanaf nul gebouwd, specifiek voor jouw bedrijf.
-							Je website ziet er anders uit dan die van je concurrent.
+							Geen templates. Elk ontwerp wordt vanaf nul gebouwd voor jouw bedrijf,
+							zodat je website er anders uitziet dan die van je concurrent.
 						</p>
 					</div>
 
 					<div class="space-y-4">
 						<div class="text-acid font-mono text-sm">[02]</div>
-						<h3 class="text-xl font-black uppercase tracking-tight">Teksten Schrijven Wij</h3>
+						<h3 class="text-xl font-black uppercase tracking-tight">Teksten Inbegrepen</h3>
 						<p class="text-canvas/70 leading-relaxed">
-							Geen lege Word-documenten om 23:00. Wij onderzoeken je branche, bekijken je concurrenten,
-							en schrijven teksten die klanten aanspreken.
+							Ik onderzoek je branche, bekijk je concurrenten en schrijf teksten die klanten aanspreken.
+							Heb je liever eigen teksten? Dan werken we daarmee.
 						</p>
 					</div>
 
 					<div class="space-y-4">
 						<div class="text-acid font-mono text-sm">[03]</div>
-						<h3 class="text-xl font-black uppercase tracking-tight">SEO Geoptimaliseerd</h3>
+						<h3 class="text-xl font-black uppercase tracking-tight">Razendsnel</h3>
 						<p class="text-canvas/70 leading-relaxed">
-							Vindbaar in Google. We zorgen voor de technische basis: snelle laadtijden,
-							juiste structuur, meta-tags. Zodat klanten je vinden.
+							Je site laadt in minder dan een seconde. Dat helpt niet alleen bij Google,
+							maar zorgt er ook voor dat bezoekers blijven hangen in plaats van wegklikken.
 						</p>
 					</div>
 
 					<div class="space-y-4">
 						<div class="text-acid font-mono text-sm">[04]</div>
-						<h3 class="text-xl font-black uppercase tracking-tight">Hosting Inbegrepen</h3>
+						<h3 class="text-xl font-black uppercase tracking-tight">Vindbaar in Google</h3>
 						<p class="text-canvas/70 leading-relaxed">
-							Hosting zit in de prijs. Altijd. Razendsnelle servers, SSL-certificaat,
-							backups. Geen extra kosten.
+							Snelle laadtijden, juiste structuur, meta-tags, schema markup. De technische
+							SEO-basis staat vanaf dag één zodat klanten je kunnen vinden.
 						</p>
 					</div>
 
 					<div class="space-y-4">
 						<div class="text-acid font-mono text-sm">[05]</div>
-						<h3 class="text-xl font-black uppercase tracking-tight">Mobiel Vriendelijk</h3>
+						<h3 class="text-xl font-black uppercase tracking-tight">Mobiel Eerst</h3>
 						<p class="text-canvas/70 leading-relaxed">
-							60% van je bezoekers komt via telefoon. Je website werkt perfect op elk scherm,
-							van smartphone tot desktop.
+							Meer dan de helft van je bezoekers komt via telefoon. Daar begint het ontwerp.
 						</p>
 					</div>
 
 					<div class="space-y-4">
 						<div class="text-acid font-mono text-sm">[06]</div>
-						<h3 class="text-xl font-black uppercase tracking-tight">Geld-Terug-Garantie</h3>
+						<h3 class="text-xl font-black uppercase tracking-tight">Hosting Inbegrepen</h3>
 						<p class="text-canvas/70 leading-relaxed">
-							Niet tevreden? Geld terug. Geen discussie, geen gedoe. We willen alleen
-							tevreden klanten.
+							Je website draait op Cloudflare, wereldwijd snel en altijd online. SSL zit erbij.
+							Hosting kost je niks, niet nu en niet later.
 						</p>
+					</div>
+				</div>
+			</div>
+		</section>
+
+		<!-- TWO APPROACHES: WEBSITE vs SYSTEEM -->
+		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light relative overflow-hidden">
+			<div class="max-w-6xl xl:max-w-7xl mx-auto">
+				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-6">
+					[ Twee Opties ]
+				</div>
+				<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tighter leading-[0.95] mb-6 max-w-3xl">
+					Kies Wat Bij Je Past.
+				</h2>
+				<p class="text-ink/60 text-lg mb-12 md:mb-16 max-w-2xl leading-relaxed">
+					Sommige ondernemers willen een sterke website. Anderen willen een systeem dat hun hele klantproces automatiseert. Beide kan.
+				</p>
+
+				<div class="grid md:grid-cols-2 gap-6 lg:gap-8">
+					<!-- WEBSITE -->
+					<div class="border-2 border-ink/10 p-8 lg:p-10 flex flex-col bg-canvas hover:border-ink/20 transition-colors">
+						<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-8">
+							[ Website ]
+						</div>
+
+						<h3 class="text-2xl md:text-3xl font-black uppercase tracking-tight mb-4">
+							Professioneel Online.
+						</h3>
+						<p class="text-ink/60 mb-8 leading-relaxed">
+							Een snelle, professionele website die bezoekers overtuigt. Inclusief contactformulier met automatische bevestiging via e-mail.
+						</p>
+
+						<ul class="space-y-3 mb-8 flex-grow">
+							<li class="flex items-start gap-3">
+								<span class="text-ink/40 mt-0.5">—</span>
+								<span class="text-ink/70">Website op maat, geen templates</span>
+							</li>
+							<li class="flex items-start gap-3">
+								<span class="text-ink/40 mt-0.5">—</span>
+								<span class="text-ink/70">Teksten inbegrepen (of eigen teksten)</span>
+							</li>
+							<li class="flex items-start gap-3">
+								<span class="text-ink/40 mt-0.5">—</span>
+								<span class="text-ink/70">Mobiel-vriendelijk & razendsnel</span>
+							</li>
+							<li class="flex items-start gap-3">
+								<span class="text-ink/40 mt-0.5">—</span>
+								<span class="text-ink/70">SEO-basis & Google vindbaar</span>
+							</li>
+							<li class="flex items-start gap-3">
+								<span class="text-ink/40 mt-0.5">—</span>
+								<span class="text-ink/70">Contactformulier met e-mail bevestiging</span>
+							</li>
+							<li class="flex items-start gap-3">
+								<span class="text-ink/40 mt-0.5">—</span>
+								<span class="text-ink/70">Hosting via Cloudflare inbegrepen</span>
+							</li>
+						</ul>
+
+						<div class="border-t border-ink/10 pt-6">
+							<div class="flex items-baseline gap-3 mb-1">
+								<span class="text-4xl lg:text-5xl font-black tracking-tight">€495</span>
+								<span class="text-ink/60 font-mono text-xs">eenmalig</span>
+							</div>
+							<p class="text-ink/50 text-sm mb-6">excl. BTW · klaar in 7 dagen</p>
+
+							<a
+								href="/aanvragen"
+								class="w-full bg-ink text-canvas py-4 font-bold uppercase tracking-tight text-sm hover:bg-ink/80 transition-colors duration-300 text-center inline-flex items-center justify-center gap-3 group"
+							>
+								Kies Website
+								<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
+							</a>
+						</div>
+					</div>
+
+					<!-- SYSTEEM -->
+					<div class="border-2 border-acid bg-acid p-8 lg:p-10 flex flex-col relative">
+						<div class="flex items-center justify-between mb-8">
+							<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60">
+								[ Systeem ]
+							</div>
+							<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60">
+								Meest Gekozen
+							</div>
+						</div>
+
+						<h3 class="text-2xl md:text-3xl font-black uppercase tracking-tight mb-4">
+							Je Digitale Medewerker.
+						</h3>
+						<p class="text-ink/70 mb-8 leading-relaxed font-medium">
+							Alles uit Website, plus slimme automations. Boekt afspraken, vraagt reviews, stuurt herinneringen. Werkt 24/7.
+						</p>
+
+						<ul class="space-y-3 mb-8 flex-grow">
+							<li class="flex items-start gap-3">
+								<span class="text-ink/50 mt-0.5">—</span>
+								<span class="text-ink/80">Alles uit Website, plus:</span>
+							</li>
+							<li class="flex items-start gap-3">
+								<span class="text-ink mt-0.5">✓</span>
+								<span class="text-ink font-medium">Afsprakenplanner / booking</span>
+							</li>
+							<li class="flex items-start gap-3">
+								<span class="text-ink mt-0.5">✓</span>
+								<span class="text-ink font-medium">Automatische review-verzoeken</span>
+							</li>
+							<li class="flex items-start gap-3">
+								<span class="text-ink mt-0.5">✓</span>
+								<span class="text-ink font-medium">Gemiste oproep SMS</span>
+							</li>
+							<li class="flex items-start gap-3">
+								<span class="text-ink mt-0.5">✓</span>
+								<span class="text-ink font-medium">iDEAL / Wero betalingen</span>
+							</li>
+							<li class="flex items-start gap-3">
+								<span class="text-ink mt-0.5">✓</span>
+								<span class="text-ink font-medium">Lead opvolging & nurturing</span>
+							</li>
+						</ul>
+
+						<div class="border-t border-ink/20 pt-6">
+							<div class="flex items-baseline gap-3 mb-1">
+								<span class="text-4xl lg:text-5xl font-black tracking-tight">€995</span>
+								<span class="text-ink/70 font-mono text-xs">eenmalig</span>
+							</div>
+							<p class="text-ink/60 text-sm mb-6">excl. BTW · klaar in 2-3 weken</p>
+
+							<a
+								href="/aanvragen"
+								class="w-full bg-ink text-acid py-4 font-bold uppercase tracking-tight text-sm hover:bg-ink/80 transition-colors duration-300 text-center inline-flex items-center justify-center gap-3 group"
+							>
+								Kies Systeem
+								<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
+							</a>
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+
+		<!-- MONTHLY SERVICE EXPLAINED -->
+		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-ink text-canvas bg-grid-dark relative overflow-hidden">
+			<div class="max-w-6xl xl:max-w-7xl mx-auto">
+				<div class="text-xs font-mono uppercase tracking-[0.2em] text-acid mb-6">
+					[ Maandelijks Beheer ]
+				</div>
+				<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tighter leading-[0.95] mb-6 max-w-3xl">
+					Wat Kost Het Per Maand?
+				</h2>
+				<p class="text-canvas/70 text-lg mb-12 max-w-2xl leading-relaxed">
+					Hosting is altijd gratis. Maar een website onderhouden kost tijd. Ik doe dat graag voor je, zodat jij je kunt focussen op je bedrijf.
+				</p>
+
+				<div class="grid md:grid-cols-2 gap-6 lg:gap-8 mb-12">
+					<!-- Website monthly -->
+					<div class="p-6 lg:p-8 border border-canvas/10 bg-canvas/5">
+						<div class="flex items-baseline justify-between mb-6">
+							<div class="text-canvas/60 font-mono text-xs uppercase tracking-widest">Website Beheer</div>
+							<div class="text-canvas/40 font-mono text-xs uppercase">Optioneel</div>
+						</div>
+						<div class="text-3xl font-black mb-4">€28,30<span class="text-canvas/60 text-lg font-normal">/maand</span></div>
+						<ul class="space-y-3 text-canvas/70 text-sm">
+							<li class="flex items-start gap-3">
+								<span class="text-acid mt-0.5">✓</span>
+								<span>Kleine aanpassingen via WhatsApp</span>
+							</li>
+							<li class="flex items-start gap-3">
+								<span class="text-acid mt-0.5">✓</span>
+								<span>Maandelijkse prestatie-rapportage</span>
+							</li>
+							<li class="flex items-start gap-3">
+								<span class="text-acid mt-0.5">✓</span>
+								<span>Uptime monitoring & snelheidschecks</span>
+							</li>
+							<li class="flex items-start gap-3">
+								<span class="text-acid mt-0.5">✓</span>
+								<span>SEO-optimalisatie & Google Search Console</span>
+							</li>
+						</ul>
+						<p class="text-canvas/40 text-xs mt-6">
+							Niet verplicht. Je website werkt prima zonder. Dit is voor als je niet wilt nadenken over onderhoud.
+						</p>
+					</div>
+
+					<!-- Systeem monthly -->
+					<div class="p-6 lg:p-8 border-2 border-acid bg-acid/10 relative">
+						<div class="absolute -top-3 right-6 bg-acid text-ink px-3 py-1 text-xs font-bold uppercase">Inclusief bij Systeem</div>
+						<div class="flex items-baseline justify-between mb-6">
+							<div class="text-acid font-mono text-xs uppercase tracking-widest">Systeem Beheer</div>
+						</div>
+						<div class="text-3xl font-black mb-4">€42,60<span class="text-canvas/60 text-lg font-normal">/maand</span></div>
+						<ul class="space-y-3 text-canvas/80 text-sm">
+							<li class="flex items-start gap-3">
+								<span class="text-acid mt-0.5">✓</span>
+								<span>Alles uit Website Beheer</span>
+							</li>
+							<li class="flex items-start gap-3">
+								<span class="text-acid mt-0.5">✓</span>
+								<span>Automations draaien & monitoren</span>
+							</li>
+							<li class="flex items-start gap-3">
+								<span class="text-acid mt-0.5">✓</span>
+								<span>Server onderhoud voor booking & betalingen</span>
+							</li>
+							<li class="flex items-start gap-3">
+								<span class="text-acid mt-0.5">✓</span>
+								<span>Prioriteit support</span>
+							</li>
+						</ul>
+						<p class="text-canvas/50 text-xs mt-6">
+							Bij het Systeem-pakket hoort dit erbij. Je automations draaien op een server die onderhouden moet worden.
+						</p>
+					</div>
+				</div>
+
+				<p class="text-canvas/50 text-sm font-mono">
+					Alle prijzen zijn exclusief BTW. Geen verborgen kosten, geen verplichte contractperiode.
+				</p>
+			</div>
+		</section>
+
+		<!-- OWNERSHIP / NO LOCK-IN -->
+		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light relative overflow-hidden">
+			<div class="max-w-6xl xl:max-w-7xl mx-auto">
+				<div class="grid md:grid-cols-2 gap-12 md:gap-16 items-start">
+					<div>
+						<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-6">
+							[ Jouw Website, Jouw Eigendom ]
+						</div>
+						<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tighter leading-[0.95] mb-6">
+							Je Zit Nergens Aan Vast.
+						</h2>
+					</div>
+					<div class="space-y-6 text-ink/70 text-lg leading-relaxed">
+						<p>
+							Bij veel bureaus is je website gekoppeld aan hun systeem. Stop je met betalen?
+							Dan gaat je site offline. Dat vind ik niet hoe het hoort.
+						</p>
+						<p>
+							Daarom draait je website op jouw eigen Cloudflare-account. De broncode is openbaar
+							op GitHub, zodat je er altijd bij kunt. Wil je ooit verder zonder mij? Kan gewoon.
+							Je site blijft staan, precies zoals die is. Geen export, geen migratie, geen gedoe.
+						</p>
+						<p>
+							Dat is ook waarom ik geen WordPress of Wix gebruik. Die platforms maken je afhankelijk
+							van hun ecosysteem. Een statische website is van jou.
+						</p>
+					</div>
+				</div>
+
+				<div class="grid grid-cols-2 md:grid-cols-4 gap-6 mt-12 pt-12 border-t border-ink/10">
+					<div class="space-y-2">
+						<div class="text-2xl font-black">Open Source</div>
+						<p class="text-ink/60 text-sm">Broncode openbaar op GitHub</p>
+					</div>
+					<div class="space-y-2">
+						<div class="text-2xl font-black">Cloudflare</div>
+						<p class="text-ink/60 text-sm">Hosting op jouw account</p>
+					</div>
+					<div class="space-y-2">
+						<div class="text-2xl font-black">Geen CMS</div>
+						<p class="text-ink/60 text-sm">Geen platform-afhankelijkheid</p>
+					</div>
+					<div class="space-y-2">
+						<div class="text-2xl font-black">Altijd van jou</div>
+						<p class="text-ink/60 text-sm">Stop wanneer je wilt</p>
 					</div>
 				</div>
 			</div>
 		</section>
 
 		<!-- HOW IT WORKS -->
-		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light relative overflow-hidden">
+		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-ink text-canvas bg-grid-dark relative overflow-hidden">
 			<div class="max-w-6xl xl:max-w-7xl mx-auto">
-				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-6">
+				<div class="text-xs font-mono uppercase tracking-[0.2em] text-acid mb-6">
 					[ Hoe Het Werkt ]
 				</div>
-				<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tighter leading-[0.95] mb-12 md:mb-16 max-w-3xl">
-					Van Gesprek Tot Live In 7 Dagen.
+				<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tighter leading-[0.95] mb-6 max-w-3xl">
+					Van Gesprek Tot Live.
 				</h2>
+				<p class="text-canvas/70 text-lg mb-12 md:mb-16 max-w-2xl leading-relaxed">
+					Het hele traject duurt 7 dagen voor een website, 2 tot 3 weken voor een systeem. Zo ziet het eruit.
+				</p>
 
-				<div class="grid md:grid-cols-3 gap-8 md:gap-12">
-					<div class="relative">
-						<div class="text-8xl font-black text-ink/5 absolute -top-4 -left-2">1</div>
-						<div class="relative space-y-4 pt-8">
-							<h3 class="text-xl font-black uppercase tracking-tight">Kennismaking</h3>
-							<p class="text-ink/70 leading-relaxed">
-								15 minuten bellen. We bespreken je bedrijf, je doelen, wat je wilt bereiken.
-								Geen verplichtingen.
+				<div class="space-y-12 md:space-y-0 md:grid md:grid-cols-2 md:gap-x-16 md:gap-y-12">
+					<!-- Step 1 -->
+					<div class="relative border-l-2 border-acid/30 pl-8 md:pl-10">
+						<div class="absolute -left-[13px] top-0 w-6 h-6 bg-acid rounded-full flex items-center justify-center">
+							<span class="text-ink text-xs font-black">1</span>
+						</div>
+						<h3 class="text-xl font-black uppercase tracking-tight mb-3">Kennismaken</h3>
+						<p class="text-canvas/70 leading-relaxed mb-4">
+							We bellen 15 minuten. Vrijblijvend, gewoon even kennismaken. Ik ben benieuwd naar:
+						</p>
+						<ul class="space-y-2 text-canvas/60 text-sm">
+							<li class="flex items-start gap-2">
+								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span>Wat je doet en wie je klanten zijn</span>
+							</li>
+							<li class="flex items-start gap-2">
+								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span>Wat je website voor je moet doen: meer aanvragen, afspraken, bekendheid?</span>
+							</li>
+							<li class="flex items-start gap-2">
+								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span>Of je al een website hebt en wat daar wel of niet werkt</span>
+							</li>
+							<li class="flex items-start gap-2">
+								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span>Wat je mooi vindt: websites die je aanspreken, kleuren, stijl</span>
+							</li>
+						</ul>
+						<p class="text-canvas/50 text-sm mt-4">
+							Daarna stuur ik een kort voorstel zodat je precies weet wat je krijgt.
+						</p>
+					</div>
+
+					<!-- Step 2 -->
+					<div class="relative border-l-2 border-acid/30 pl-8 md:pl-10">
+						<div class="absolute -left-[13px] top-0 w-6 h-6 bg-acid rounded-full flex items-center justify-center">
+							<span class="text-ink text-xs font-black">2</span>
+						</div>
+						<h3 class="text-xl font-black uppercase tracking-tight mb-3">Jij Levert Aan</h3>
+						<p class="text-canvas/70 leading-relaxed mb-4">
+							Na het gesprek heb ik een paar dingen van je nodig:
+						</p>
+						<ul class="space-y-2 text-canvas/60 text-sm">
+							<li class="flex items-start gap-2">
+								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span>Je logo (als je dat hebt)</span>
+							</li>
+							<li class="flex items-start gap-2">
+								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span>Foto's van je werk, team of bedrijf</span>
+							</li>
+							<li class="flex items-start gap-2">
+								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span>Toegang tot je domeinnaam, of ik regel een nieuw domein</span>
+							</li>
+						</ul>
+						<p class="text-canvas/50 text-sm mt-4">
+							Heb je nog niet alles klaar? Geen probleem. We beginnen met wat er is.
+						</p>
+					</div>
+
+					<!-- Step 3 -->
+					<div class="relative border-l-2 border-acid/30 pl-8 md:pl-10">
+						<div class="absolute -left-[13px] top-0 w-6 h-6 bg-acid rounded-full flex items-center justify-center">
+							<span class="text-ink text-xs font-black">3</span>
+						</div>
+						<h3 class="text-xl font-black uppercase tracking-tight mb-3">Ik Ga Bouwen</h3>
+						<p class="text-canvas/70 leading-relaxed mb-4">
+							Dan ga ik aan de slag. Ik duik in je branche, bekijk je concurrenten en bouw je website vanaf nul.
+						</p>
+						<ul class="space-y-2 text-canvas/60 text-sm">
+							<li class="flex items-start gap-2">
+								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span>Concurrentie-analyse: wat doen anderen in jouw markt?</span>
+							</li>
+							<li class="flex items-start gap-2">
+								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span>Design: een ontwerp dat past bij jouw bedrijf</span>
+							</li>
+							<li class="flex items-start gap-2">
+								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span>Teksten: geschreven om klanten aan te spreken</span>
+							</li>
+							<li class="flex items-start gap-2">
+								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span>Techniek: snel, veilig en vindbaar in Google</span>
+							</li>
+						</ul>
+						<p class="text-canvas/50 text-sm mt-4">
+							Jij hoeft niks te doen. Na 5 dagen stuur ik het eerste ontwerp op.
+						</p>
+					</div>
+
+					<!-- Step 4 -->
+					<div class="relative border-l-2 border-acid/30 pl-8 md:pl-10">
+						<div class="absolute -left-[13px] top-0 w-6 h-6 bg-acid rounded-full flex items-center justify-center">
+							<span class="text-ink text-xs font-black">4</span>
+						</div>
+						<h3 class="text-xl font-black uppercase tracking-tight mb-3">Feedback & Finetunen</h3>
+						<p class="text-canvas/70 leading-relaxed">
+							Je bekijkt het ontwerp en geeft aan wat je ervan vindt. Andere kleur? Andere foto? Tekst
+							aanpassen? Ik pas het aan. We gaan net zo lang door tot je 100% tevreden bent. Geen haast,
+							geen extra kosten voor aanpassingen.
+						</p>
+					</div>
+
+					<!-- Step 5 -->
+					<div class="relative border-l-2 border-acid/30 pl-8 md:pl-10 md:col-span-2">
+						<div class="absolute -left-[13px] top-0 w-6 h-6 bg-acid rounded-full flex items-center justify-center">
+							<span class="text-ink text-xs font-black">5</span>
+						</div>
+						<div class="md:max-w-xl">
+							<h3 class="text-xl font-black uppercase tracking-tight mb-3">Live & Beheer</h3>
+							<p class="text-canvas/70 leading-relaxed">
+								Als je tevreden bent, zetten we de website live op jouw Cloudflare-account. Vanaf dat
+								moment is je site online en bereikbaar voor klanten. Kies je voor maandelijks beheer?
+								Dan houd ik alles in de gaten: snelheid, uptime, Google-prestaties en kleine aanpassingen
+								via WhatsApp. Zo hoef jij er niet meer naar om te kijken.
 							</p>
 						</div>
 					</div>
-
-					<div class="relative">
-						<div class="text-8xl font-black text-ink/5 absolute -top-4 -left-2">2</div>
-						<div class="relative space-y-4 pt-8">
-							<h3 class="text-xl font-black uppercase tracking-tight">Wij Bouwen</h3>
-							<p class="text-ink/70 leading-relaxed">
-								Wij gaan aan de slag. Design, teksten, techniek. Jij hoeft niks te doen.
-								Na 5 dagen krijg je het eerste ontwerp.
-							</p>
-						</div>
-					</div>
-
-					<div class="relative">
-						<div class="text-8xl font-black text-ink/5 absolute -top-4 -left-2">3</div>
-						<div class="relative space-y-4 pt-8">
-							<h3 class="text-xl font-black uppercase tracking-tight">Live</h3>
-							<p class="text-ink/70 leading-relaxed">
-								Feedback verwerken we direct. Dan gaat je website live.
-								Klaar om klanten binnen te halen.
-							</p>
-						</div>
-					</div>
-				</div>
-
-				<div class="mt-12 pt-8 border-t border-ink/10">
-					<a
-						href="/aanvragen"
-						class="bg-ink text-canvas px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink/80 transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
-					>
-						Laten we kennismaken
-						<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
-					</a>
 				</div>
 			</div>
 		</section>
 
-		<!-- PRICING COMPARISON -->
-		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-ink text-canvas bg-grid-dark relative overflow-hidden">
+		<!-- WHY NOT WORDPRESS -->
+		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light relative overflow-hidden">
 			<div class="max-w-6xl xl:max-w-7xl mx-auto">
-				<div class="text-xs font-mono uppercase tracking-[0.2em] text-acid mb-6">
-					[ Eerlijke Prijzen ]
+				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-6">
+					[ Waarom Geen WordPress ]
 				</div>
 				<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tighter leading-[0.95] mb-6 max-w-3xl">
-					Traditionele Bureaus vs. KNAP GEMAAKT.
+					Sneller. Veiliger. Goedkoper.
 				</h2>
-				<p class="text-canvas/70 text-lg mb-12 max-w-2xl">
-					Andere bureaus rekenen €2.000 tot €5.000. Wij niet.
-					Dezelfde kwaliteit, zonder de overhead.
+				<p class="text-ink/60 text-lg mb-12 max-w-2xl leading-relaxed">
+					De meeste websites draaien op WordPress, Wix of Squarespace. Dat kan prima, maar er zijn
+					een paar dingen waar je rekening mee moet houden. Ik kies voor maatwerk webdesign zonder
+					platform-afhankelijkheid. Hier is het verschil.
 				</p>
 
 				<div class="grid md:grid-cols-2 gap-8">
-					<!-- Traditional -->
-					<div class="p-8 border border-canvas/10 bg-canvas/5">
-						<div class="text-canvas/40 font-mono text-xs uppercase tracking-widest mb-4">Traditioneel Bureau</div>
-						<div class="text-4xl font-black mb-6">€2.000 - €5.000</div>
-						<ul class="space-y-3 text-canvas/60">
+					<!-- WordPress -->
+					<div class="p-8 border border-ink/10 bg-ink/5">
+						<div class="text-ink/40 font-mono text-xs uppercase tracking-widest mb-6">WordPress / Wix / Squarespace</div>
+						<ul class="space-y-4 text-ink/60">
 							<li class="flex items-start gap-3">
-								<span class="text-red-400 mt-1">✕</span>
-								<span>Weken wachten op offerte</span>
+								<span class="text-red-500 mt-1 shrink-0">✕</span>
+								<span>Laadt in 3-5 seconden gemiddeld</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-red-400 mt-1">✕</span>
-								<span>Zelf teksten aanleveren</span>
+								<span class="text-red-500 mt-1 shrink-0">✕</span>
+								<span>Plugins updaten, security patches, hackers</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-red-400 mt-1">✕</span>
-								<span>Eindeloze feedbackrondes</span>
+								<span class="text-red-500 mt-1 shrink-0">✕</span>
+								<span>€10 tot €30 per maand voor hosting</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-red-400 mt-1">✕</span>
-								<span>4-8 weken doorlooptijd</span>
+								<span class="text-red-500 mt-1 shrink-0">✕</span>
+								<span>Website weg als je stopt met betalen</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-red-400 mt-1">✕</span>
-								<span>Extra kosten voor hosting</span>
+								<span class="text-red-500 mt-1 shrink-0">✕</span>
+								<span>Gebonden aan het platform</span>
 							</li>
 						</ul>
 					</div>
 
-					<!-- KNAP GEMAAKT -->
-					<div class="p-8 border-2 border-acid bg-acid/10 relative">
-						<div class="absolute -top-3 right-8 bg-acid text-ink px-3 py-1 text-xs font-bold uppercase">Onze aanpak</div>
-						<div class="text-acid font-mono text-xs uppercase tracking-widest mb-4">KNAP GEMAAKT.</div>
-						<div class="text-4xl font-black mb-6">€595</div>
-						<ul class="space-y-3 text-canvas/80">
+					<!-- Static -->
+					<div class="p-8 border-2 border-acid bg-acid/5 relative">
+						<div class="absolute -top-3 right-8 bg-acid text-ink px-3 py-1 text-xs font-bold uppercase">Mijn aanpak</div>
+						<div class="text-electric font-mono text-xs uppercase tracking-widest mb-6">Statische Website</div>
+						<ul class="space-y-4 text-ink/80">
 							<li class="flex items-start gap-3">
-								<span class="text-acid mt-1">✓</span>
-								<span>Vaste prijs, geen verrassingen</span>
+								<span class="text-electric mt-1 shrink-0">✓</span>
+								<span>Laadt in minder dan 1 seconde</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-acid mt-1">✓</span>
-								<span>Wij schrijven de teksten</span>
+								<span class="text-electric mt-1 shrink-0">✓</span>
+								<span>Geen plugins, geen updates, niets te hacken</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-acid mt-1">✓</span>
-								<span>7 dagen doorlooptijd</span>
+								<span class="text-electric mt-1 shrink-0">✓</span>
+								<span>Hosting is gratis via Cloudflare</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-acid mt-1">✓</span>
-								<span>Hosting altijd inbegrepen</span>
+								<span class="text-electric mt-1 shrink-0">✓</span>
+								<span>Site blijft online, ook zonder mij</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-acid mt-1">✓</span>
-								<span>100% tevredenheidsgarantie</span>
+								<span class="text-electric mt-1 shrink-0">✓</span>
+								<span>Broncode is openbaar, geen platform lock-in</span>
 							</li>
 						</ul>
 					</div>
 				</div>
-
-				<p class="text-canvas/50 text-sm mt-8 font-mono">
-					Webshop nodig? Die bouwen we voor €1795, klaar in 2-3 weken.
-				</p>
 			</div>
 		</section>
 
 		<!-- FAQ SECTION -->
-		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light relative overflow-hidden">
+		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-ink text-canvas bg-grid-dark relative overflow-hidden">
 			<div class="max-w-6xl xl:max-w-7xl mx-auto">
-				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-6">
+				<div class="text-xs font-mono uppercase tracking-[0.2em] text-acid mb-6">
 					[ Veelgestelde Vragen ]
 				</div>
 				<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tighter leading-[0.95] mb-12 md:mb-16">
-					Vragen Over Website Laten Maken?
+					Vragen?
 				</h2>
 
 				<div class="grid md:grid-cols-2 gap-8 md:gap-12">
 					<div class="space-y-8">
 						{faqs.slice(0, 3).map((faq) => (
 							<div class="space-y-3">
-								<h3 class="text-lg font-bold text-electric">{faq.question}</h3>
-								<p class="text-ink/70 leading-relaxed">{faq.answer}</p>
+								<h3 class="text-lg font-bold text-acid">{faq.question}</h3>
+								<p class="text-canvas/70 leading-relaxed">{faq.answer}</p>
 							</div>
 						))}
 					</div>
 					<div class="space-y-8">
 						{faqs.slice(3).map((faq) => (
 							<div class="space-y-3">
-								<h3 class="text-lg font-bold text-electric">{faq.question}</h3>
-								<p class="text-ink/70 leading-relaxed">{faq.answer}</p>
+								<h3 class="text-lg font-bold text-acid">{faq.question}</h3>
+								<p class="text-canvas/70 leading-relaxed">{faq.answer}</p>
 							</div>
 						))}
 					</div>


### PR DESCRIPTION
## Summary
- Complete rewrite of `website-laten-maken.astro` with 2-tier pricing (Website €495 / Systeem €995)
- Expanded 5-step "How It Works" timeline with detailed process breakdown
- SEO optimization: BreadcrumbSchema, keyword integration (maatwerk, op maat), AEO intro paragraph
- Updated `index.astro`: replaced OfferSection with compact pricing CTA, updated we→ik positioning
- Removed OfferSection from `webdesign-[city].astro`

## Test plan
- [ ] Verify build passes (`npx astro build`)
- [ ] Preview website-laten-maken page layout and pricing cards
- [ ] Verify FAQ schema and BreadcrumbSchema render in page source
- [ ] Check mobile responsiveness of new 5-step timeline
- [ ] Verify all internal links work (/aanvragen CTAs)

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)