### PR TITLE
fix(a11y): increase text contrast for WCAG AA compliance 🐛

### DIFF
--- a/src/components/ConceptShowcase.astro
+++ b/src/components/ConceptShowcase.astro
@@ -66,7 +66,7 @@ const projects: Project[] = [
         </div>
         <div class="hidden md:block text-right">
             <span
-                class="font-mono text-xs uppercase tracking-widest text-ink/40"
+                class="font-mono text-xs uppercase tracking-widest text-ink/60"
                 >Ons Portfolio</span
             >
         </div>

--- a/src/components/OfferSection.astro
+++ b/src/components/OfferSection.astro
@@ -38,23 +38,23 @@
 
 				<ul class="space-y-3 mb-8 flex-grow text-sm">
 					<li class="flex items-start gap-2">
-						<span class="text-ink/40">—</span>
+						<span class="text-ink/60">—</span>
 						<span class="text-ink/70">Professioneel design op maat</span>
 					</li>
 					<li class="flex items-start gap-2">
-						<span class="text-ink/40">—</span>
+						<span class="text-ink/60">—</span>
 						<span class="text-ink/70">Teksten geschreven</span>
 					</li>
 					<li class="flex items-start gap-2">
-						<span class="text-ink/40">—</span>
+						<span class="text-ink/60">—</span>
 						<span class="text-ink/70">Mobiel-vriendelijk & razendsnel</span>
 					</li>
 					<li class="flex items-start gap-2">
-						<span class="text-ink/40">—</span>
+						<span class="text-ink/60">—</span>
 						<span class="text-ink/70">Hosting inbegrepen</span>
 					</li>
 					<li class="flex items-start gap-2">
-						<span class="text-ink/40">—</span>
+						<span class="text-ink/60">—</span>
 						<span class="text-ink/70">Automatische e-mail bevestiging</span>
 					</li>
 				</ul>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -54,7 +54,7 @@ import Footer from "../components/Footer.astro";
 
             <!-- Quick Navigation -->
             <div class="mt-12 w-full max-w-xl">
-                <p class="text-sm font-mono text-ink/40 uppercase tracking-widest mb-6">
+                <p class="text-sm font-mono text-ink/60 uppercase tracking-widest mb-6">
                     Misschien zoek je dit?
                 </p>
                 <div class="grid grid-cols-2 gap-3">

--- a/src/pages/aanvragen.astro
+++ b/src/pages/aanvragen.astro
@@ -19,7 +19,7 @@ import Footer from "../components/Footer.astro";
                     />
                     <a
                         href="/contact"
-                        class="text-sm font-mono text-ink/40 hover:text-electric transition-colors whitespace-nowrap self-start md:self-auto md:mt-4"
+                        class="text-sm font-mono text-ink/60 hover:text-electric transition-colors whitespace-nowrap self-start md:self-auto md:mt-4"
                     >
                         Liever direct contact? &rarr;
                     </a>
@@ -157,7 +157,7 @@ import Footer from "../components/Footer.astro";
                                 <option value="Anders">Anders</option>
                             </select>
                             <div
-                                class="absolute right-0 top-1/2 -translate-y-1/2 pointer-events-none text-ink/40"
+                                class="absolute right-0 top-1/2 -translate-y-1/2 pointer-events-none text-ink/60"
                             >
                                 <svg
                                     xmlns="http://www.w3.org/2000/svg"
@@ -272,7 +272,7 @@ import Footer from "../components/Footer.astro";
                             <option value="Anders">Anders</option>
                         </select>
                         <div
-                            class="absolute right-0 top-1/2 -translate-y-1/2 pointer-events-none text-ink/40"
+                            class="absolute right-0 top-1/2 -translate-y-1/2 pointer-events-none text-ink/60"
                         >
                             <svg
                                 xmlns="http://www.w3.org/2000/svg"
@@ -307,7 +307,7 @@ import Footer from "../components/Footer.astro";
                         id="cal-placeholder"
                         class="py-12 border border-dashed border-white/20 text-center lg:border-ink/20"
                     >
-                        <p class="text-white/40 font-medium lg:text-ink/40">
+                        <p class="text-white/40 font-medium lg:text-ink/60">
                             Vul eerst je gegevens in om een moment te kiezen
                         </p>
                     </div>
@@ -367,7 +367,7 @@ import Footer from "../components/Footer.astro";
                             </svg>
                         </span>
                     </button>
-                    <p class="mt-4 text-xs font-mono text-ink/40">
+                    <p class="mt-4 text-xs font-mono text-ink/60">
                         * Je ontvangt direct een bevestiging per e-mail. We bellen je op het gekozen tijdstip.
                     </p>
                 </div>

--- a/src/pages/algemene-voorwaarden.astro
+++ b/src/pages/algemene-voorwaarden.astro
@@ -36,7 +36,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >01.</span
                         >
                     </div>
@@ -71,7 +71,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >02.</span
                         >
                     </div>
@@ -100,7 +100,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >03.</span
                         >
                     </div>
@@ -128,7 +128,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >04.</span
                         >
                     </div>
@@ -164,7 +164,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >05.</span
                         >
                     </div>
@@ -198,7 +198,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >06.</span
                         >
                     </div>
@@ -230,7 +230,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >07.</span
                         >
                     </div>
@@ -265,7 +265,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >08.</span
                         >
                     </div>
@@ -297,7 +297,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >09.</span
                         >
                     </div>
@@ -326,7 +326,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >10.</span
                         >
                     </div>

--- a/src/pages/automations.astro
+++ b/src/pages/automations.astro
@@ -251,7 +251,7 @@ const steps = [
 		<!-- SECTION 3: WHAT'S POSSIBLE — before/after (light) -->
 		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light relative overflow-hidden">
 			<div class="max-w-6xl xl:max-w-7xl mx-auto">
-				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-6">
+				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-6">
 					[ Dit Kan Allemaal ]
 				</div>
 				<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tight leading-[0.95] mb-6 max-w-3xl">
@@ -267,14 +267,14 @@ const steps = [
 							<div class="flex items-start gap-3 mb-4">
 								<span class="text-red-500 mt-0.5 shrink-0 font-bold">✕</span>
 								<div>
-									<span class="text-xs font-mono uppercase tracking-widest text-ink/40 block mb-1">Voor</span>
+									<span class="text-xs font-mono uppercase tracking-widest text-ink/60 block mb-1">Voor</span>
 									<p class="text-ink/60 leading-relaxed">{item.before}</p>
 								</div>
 							</div>
 							<div class="flex items-start gap-3">
 								<span class="text-emerald-600 mt-0.5 shrink-0 font-bold">✓</span>
 								<div>
-									<span class="text-xs font-mono uppercase tracking-widest text-ink/40 block mb-1">Nu</span>
+									<span class="text-xs font-mono uppercase tracking-widest text-ink/60 block mb-1">Nu</span>
 									<p class="text-ink/80 leading-relaxed font-medium">{item.after}</p>
 								</div>
 							</div>
@@ -327,7 +327,7 @@ const steps = [
 		<!-- SECTION 6: OFFERTE FORM (light) -->
 		<section id="offerte" class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light relative overflow-hidden">
 			<div class="max-w-3xl mx-auto">
-				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-6">
+				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-6">
 					[ Offerte Aanvragen ]
 				</div>
 				<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tight leading-[0.95] mb-6">
@@ -455,7 +455,7 @@ const steps = [
 								</svg>
 							</span>
 						</button>
-						<p class="mt-4 text-xs font-mono text-ink/40">
+						<p class="mt-4 text-xs font-mono text-ink/60">
 							Ik reageer binnen 24 uur. Geen verplichtingen.
 						</p>
 					</div>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -34,7 +34,7 @@ const breadcrumbs = [
 		<!-- Hero Section -->
 		<section class="pt-32 pb-16 md:pb-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light relative overflow-hidden">
 			<div class="max-w-6xl xl:max-w-7xl mx-auto relative z-10">
-				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-4">
+				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-4">
 					[ Artikelen & Inzichten ]
 				</div>
 				<h1 class="text-5xl md:text-7xl lg:text-8xl font-black uppercase tracking-tight leading-[0.9] mb-6">
@@ -52,7 +52,7 @@ const breadcrumbs = [
 			<section class="px-6 md:px-12 lg:px-16 bg-canvas border-b border-ink/10">
 				<div class="max-w-6xl xl:max-w-7xl mx-auto py-6">
 					<div class="flex flex-wrap items-center gap-3">
-						<span class="text-xs font-mono uppercase tracking-wider text-ink/40">
+						<span class="text-xs font-mono uppercase tracking-wider text-ink/60">
 							Filter:
 						</span>
 						<a

--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -54,7 +54,7 @@ const breadcrumbs = [
 		<!-- Hero Section -->
 		<section class="pt-32 pb-16 md:pb-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light relative overflow-hidden">
 			<div class="max-w-6xl xl:max-w-7xl mx-auto relative z-10">
-				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-4">
+				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-4">
 					[ Artikelen over {tag} ]
 				</div>
 				<h1 class="text-5xl md:text-7xl lg:text-8xl font-black uppercase tracking-tight leading-[0.9] mb-6">
@@ -70,7 +70,7 @@ const breadcrumbs = [
 		<section class="px-6 md:px-12 lg:px-16 bg-canvas border-b border-ink/10">
 			<div class="max-w-6xl xl:max-w-7xl mx-auto py-6">
 				<div class="flex flex-wrap items-center gap-3">
-					<span class="text-xs font-mono uppercase tracking-wider text-ink/40">
+					<span class="text-xs font-mono uppercase tracking-wider text-ink/60">
 						Filter:
 					</span>
 					<a

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -119,7 +119,7 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 										<option value="Vraag">Algemene vraag</option>
 										<option value="Anders">Anders</option>
 									</select>
-									<div class="absolute right-0 top-1/2 -translate-y-1/2 pointer-events-none text-ink/40">
+									<div class="absolute right-0 top-1/2 -translate-y-1/2 pointer-events-none text-ink/60">
 										<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square" stroke-linejoin="miter"><path d="m6 9 6 6 6-6"></path></svg>
 									</div>
 								</div>
@@ -225,7 +225,7 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 										href="https://www.linkedin.com/in/yannick-veldhuisen-303047243/"
 										target="_blank"
 										rel="noopener noreferrer"
-										class="text-xs font-mono text-ink/40 hover:text-electric transition-colors uppercase tracking-widest"
+										class="text-xs font-mono text-ink/60 hover:text-electric transition-colors uppercase tracking-widest"
 									>
 										LinkedIn &rarr;
 									</a>
@@ -241,7 +241,7 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 
 			<!-- Contact Info Section -->
 			<div class="border-t-2 border-ink/10 pt-16 mb-16">
-				<h2 class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-8">Direct contact</h2>
+				<h2 class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-8">Direct contact</h2>
 				<div class="grid grid-cols-1 md:grid-cols-3 gap-6">
 					<!-- Email -->
 					<a
@@ -298,7 +298,7 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 			</div>
 
 			<!-- Business Info -->
-			<div class="flex flex-wrap gap-x-8 gap-y-2 font-mono text-xs text-ink/40 uppercase tracking-widest">
+			<div class="flex flex-wrap gap-x-8 gap-y-2 font-mono text-xs text-ink/60 uppercase tracking-widest">
 				<span>KvK: 73652377</span>
 				<span>BTW: NL002383577B12</span>
 			</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -125,7 +125,7 @@ const projects = getAllProjects();
 		<!-- SERVICES SECTION -->
 		<section id="diensten" class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light relative overflow-hidden">
 			<div class="max-w-6xl xl:max-w-7xl mx-auto">
-				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-6">
+				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-6">
 					[ Wat Ik Voor Je Kan Doen ]
 				</div>
 				<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tight leading-[0.95] mb-12 md:mb-16 max-w-3xl">
@@ -229,7 +229,7 @@ const projects = getAllProjects();
 		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-canvas border-y-2 border-ink/10 relative overflow-hidden">
 			<div class="max-w-4xl mx-auto">
 				<div class="text-center mb-12">
-					<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-4">
+					<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-4">
 						[ Gratis Website Check ]
 					</div>
 					<h2 class="text-3xl md:text-4xl font-black uppercase tracking-tight leading-[0.95] mb-4">

--- a/src/pages/over-mij.astro
+++ b/src/pages/over-mij.astro
@@ -190,7 +190,7 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 
 			<!-- Future Hint -->
 			<div class="mb-24 p-8 md:p-10 bg-ink/[0.03] border-l-4 border-acid">
-				<p class="text-sm font-mono uppercase tracking-widest text-ink/40 mb-3">Waar ik mee bezig ben</p>
+				<p class="text-sm font-mono uppercase tracking-widest text-ink/60 mb-3">Waar ik mee bezig ben</p>
 				<p class="text-lg text-ink/80 leading-relaxed max-w-2xl">
 					Ik werk aan een dashboard waar je zelf je teksten kunt aanpassen,
 					kunt zien hoeveel bezoekers je hebt gehad en wat daaruit is

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -22,7 +22,7 @@ const breadcrumbs = [
         <!-- Hero Section -->
         <section class="pt-32 pb-16 md:pb-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light relative overflow-hidden">
             <div class="max-w-6xl xl:max-w-7xl mx-auto relative z-10">
-                <div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-4">
+                <div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-4">
                     [ Mijn Werk ]
                 </div>
                 <h1 class="text-5xl md:text-7xl lg:text-8xl font-black uppercase tracking-tight leading-[0.9] mb-6">

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -36,7 +36,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >01.</span
                         >
                     </div>
@@ -71,7 +71,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >02.</span
                         >
                     </div>
@@ -109,7 +109,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >03.</span
                         >
                     </div>
@@ -148,7 +148,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >04.</span
                         >
                     </div>
@@ -192,7 +192,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >05.</span
                         >
                     </div>
@@ -220,7 +220,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >06.</span
                         >
                     </div>
@@ -249,7 +249,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >07.</span
                         >
                     </div>
@@ -277,7 +277,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >08.</span
                         >
                     </div>
@@ -309,7 +309,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >09.</span
                         >
                     </div>
@@ -368,7 +368,7 @@ import Footer from "../components/Footer.astro";
                     class="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-12 md:py-20 border-b border-ink/10"
                 >
                     <div class="md:col-span-3">
-                        <span class="text-xl md:text-2xl font-mono text-ink/40"
+                        <span class="text-xl md:text-2xl font-mono text-ink/60"
                             >10.</span
                         >
                     </div>

--- a/src/pages/project/[slug].astro
+++ b/src/pages/project/[slug].astro
@@ -35,7 +35,7 @@ const pageTitle = `Maatwerk website voor ${project.title} | ${project.industry}`
 		<section class="pt-32 pb-16 md:pb-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light relative overflow-hidden">
 			<div class="max-w-6xl xl:max-w-7xl mx-auto relative z-10">
 				<!-- Breadcrumb -->
-				<div class="flex items-center gap-2 text-ink/40 font-mono text-xs uppercase tracking-wider mb-8">
+				<div class="flex items-center gap-2 text-ink/60 font-mono text-xs uppercase tracking-wider mb-8">
 					<a href="/" class="hover:text-electric transition-colors">Home</a>
 					<span>/</span>
 					<a href="/portfolio" class="hover:text-electric transition-colors">Projecten</a>
@@ -122,7 +122,7 @@ const pageTitle = `Maatwerk website voor ${project.title} | ${project.industry}`
 				<div class="grid md:grid-cols-2 gap-12 md:gap-16 lg:gap-20">
 					<!-- Challenge -->
 					<div>
-						<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-4">
+						<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-4">
 							[ Uitdaging ]
 						</div>
 						<h2 class="text-2xl md:text-3xl lg:text-4xl font-black uppercase tracking-tight mb-6">
@@ -135,7 +135,7 @@ const pageTitle = `Maatwerk website voor ${project.title} | ${project.industry}`
 
 					<!-- Solution -->
 					<div>
-						<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-4">
+						<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-4">
 							[ Oplossing ]
 						</div>
 						<h2 class="text-2xl md:text-3xl lg:text-4xl font-black uppercase tracking-tight mb-6">
@@ -198,7 +198,7 @@ const pageTitle = `Maatwerk website voor ${project.title} | ${project.industry}`
 		{project.results && project.results.length > 0 && (
 			<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light relative overflow-hidden">
 				<div class="max-w-4xl mx-auto relative z-10">
-					<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-4">
+					<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-4">
 						[ Resultaat ]
 					</div>
 					<h2 class="text-3xl md:text-4xl lg:text-5xl font-black uppercase tracking-tight mb-8">
@@ -241,7 +241,7 @@ const pageTitle = `Maatwerk website voor ${project.title} | ${project.industry}`
 			<div class="max-w-6xl xl:max-w-7xl mx-auto relative z-10">
 				<div class="flex items-center justify-between mb-12">
 					<div>
-						<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-4">
+						<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-4">
 							[ Mijn Werk ]
 						</div>
 						<h2 class="text-3xl md:text-4xl lg:text-5xl font-black uppercase tracking-tight">

--- a/src/pages/sitemap.astro
+++ b/src/pages/sitemap.astro
@@ -15,7 +15,7 @@ const blogPosts = getAllBlogPosts();
         <div class="max-w-6xl xl:max-w-7xl mx-auto relative z-10">
             <!-- Header -->
             <div class="mb-16">
-                <div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-4">
+                <div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-4">
                     [ Navigatie ]
                 </div>
                 <h1 class="text-5xl md:text-7xl lg:text-8xl font-black uppercase tracking-tight leading-[0.9] mb-6">

--- a/src/pages/webdesign-[city].astro
+++ b/src/pages/webdesign-[city].astro
@@ -65,7 +65,7 @@ const breadcrumbs = [
                 <div class="grid md:grid-cols-2 gap-8 md:gap-12 items-center">
                     <!-- Text Content -->
                     <div class="space-y-6">
-                        <div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40">
+                        <div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60">
                             [ Lokale Partner in {cityData.region} ]
                         </div>
                         <h1 class="text-4xl md:text-5xl lg:text-6xl font-black uppercase tracking-tight leading-[0.9]">

--- a/src/pages/website-laten-maken.astro
+++ b/src/pages/website-laten-maken.astro
@@ -180,7 +180,7 @@ const faqs = [
 		<!-- TWO APPROACHES: WEBSITE vs SYSTEEM -->
 		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light relative overflow-hidden">
 			<div class="max-w-6xl xl:max-w-7xl mx-auto">
-				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-6">
+				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-6">
 					[ Twee Opties ]
 				</div>
 				<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tight leading-[0.95] mb-6 max-w-3xl">
@@ -206,27 +206,27 @@ const faqs = [
 
 						<ul class="space-y-3 mb-8 flex-grow">
 							<li class="flex items-start gap-3">
-								<span class="text-ink/40 mt-0.5">—</span>
+								<span class="text-ink/60 mt-0.5">—</span>
 								<span class="text-ink/70">Website op maat, geen templates</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-ink/40 mt-0.5">—</span>
+								<span class="text-ink/60 mt-0.5">—</span>
 								<span class="text-ink/70">Teksten inbegrepen (of eigen teksten)</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-ink/40 mt-0.5">—</span>
+								<span class="text-ink/60 mt-0.5">—</span>
 								<span class="text-ink/70">Mobiel-vriendelijk & razendsnel</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-ink/40 mt-0.5">—</span>
+								<span class="text-ink/60 mt-0.5">—</span>
 								<span class="text-ink/70">SEO-basis & Google vindbaar</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-ink/40 mt-0.5">—</span>
+								<span class="text-ink/60 mt-0.5">—</span>
 								<span class="text-ink/70">Contactformulier met e-mail bevestiging</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-ink/40 mt-0.5">—</span>
+								<span class="text-ink/60 mt-0.5">—</span>
 								<span class="text-ink/70">Hosting via Cloudflare inbegrepen</span>
 							</li>
 						</ul>
@@ -399,7 +399,7 @@ const faqs = [
 			<div class="max-w-6xl xl:max-w-7xl mx-auto">
 				<div class="grid md:grid-cols-2 gap-12 md:gap-16 items-start">
 					<div>
-						<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-6">
+						<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-6">
 							[ Jouw Website, Jouw Eigendom ]
 						</div>
 						<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tight leading-[0.95] mb-6">
@@ -585,7 +585,7 @@ const faqs = [
 		<!-- WHY NOT WORDPRESS -->
 		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light relative overflow-hidden">
 			<div class="max-w-6xl xl:max-w-7xl mx-auto">
-				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/40 mb-6">
+				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-6">
 					[ Waarom Geen WordPress ]
 				</div>
 				<h2 class="text-3xl md:text-5xl font-black uppercase tracking-tight leading-[0.95] mb-6 max-w-3xl">
@@ -600,7 +600,7 @@ const faqs = [
 				<div class="grid md:grid-cols-2 gap-8">
 					<!-- WordPress -->
 					<div class="p-8 border border-ink/10 bg-ink/5">
-						<div class="text-ink/40 font-mono text-xs uppercase tracking-widest mb-6">WordPress / Wix / Squarespace</div>
+						<div class="text-ink/60 font-mono text-xs uppercase tracking-widest mb-6">WordPress / Wix / Squarespace</div>
 						<ul class="space-y-4 text-ink/60">
 							<li class="flex items-start gap-3">
 								<span class="text-red-500 mt-1 shrink-0">✕</span>


### PR DESCRIPTION
## Summary
- Increased text opacity from 40% to 60% across all pages and components
- This brings the contrast ratio from ~2.85:1 to ~5.74:1 (WCAG AA requires 4.5:1)
- Fixes low-contrast text on labels like "[ GRATIS WEBSITE CHECK ]" and section headers

## Files Changed
17 files updated (pages + components) - all instances of `text-ink/40` → `text-ink/60`

## Test Plan
- [x] Verified no remaining `text-ink/40` instances in `.astro` files
- [ ] Visual check that text is still readable and design looks good

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)