### PR TITLE
feat(404): redesign with friendly dry humor ✨

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,90 +5,67 @@ import Layout from "../layouts/Layout.astro";
 import Footer from "../components/Footer.astro";
 ---
 
-<Layout title="404 - Verdwaald? | KNAP GEMAAKT.">
-    <main
-        class="relative flex flex-col items-center justify-center min-h-screen bg-canvas text-ink overflow-hidden selection:bg-black selection:text-acid bg-grid-light"
-    >
-        <!-- Massive Background 404 - Moved to bottom corner to avoid text overlap -->
-        <div
-            class="absolute bottom-0 left-0 pointer-events-none z-0 overflow-hidden leading-none"
-        >
-            <h1
-                class="text-[40vw] font-black leading-none tracking-tight text-ink opacity-[0.04] select-none translate-y-[20%] -translate-x-[10%]"
-            >
-                404
-            </h1>
-        </div>
+<Layout title="404 | KNAP GEMAAKT.">
+	<main class="bg-canvas">
+		<section class="min-h-screen flex flex-col justify-center relative overflow-hidden px-6 md:px-12 lg:px-16 py-24">
+			<!-- Soft gradient background -->
+			<div class="absolute inset-0 bg-gradient-to-br from-canvas via-canvas to-acid/5 pointer-events-none"></div>
 
-        <div
-            class="relative z-10 flex flex-col items-center text-center px-6 max-w-3xl mx-auto"
-        >
-            <div class="mb-6">
-                <span
-                    class="inline-block px-4 py-1.5 bg-acid text-black text-xs md:text-sm font-bold uppercase tracking-[0.2em] border border-black"
-                >
-                    Page Not Found
-                </span>
-            </div>
+			<div class="max-w-2xl mx-auto w-full relative z-10 text-center">
+				<!-- Big 404 -->
+				<div class="mb-6">
+					<span class="text-8xl md:text-9xl font-black tracking-tight text-ink/10 select-none">404</span>
+				</div>
 
-            <h2
-                class="text-5xl md:text-8xl font-black uppercase tracking-tight mb-8 leading-[0.9]"
-            >
-                Oeps.<br /> Hier is niks.
-            </h2>
+				<h1 class="text-2xl sm:text-3xl md:text-4xl font-black tracking-tight leading-[1.1] mb-4">
+					Verkeerde afslag.
+				</h1>
 
-            <div class="space-y-6 mb-12">
-                <p
-                    class="text-xl md:text-2xl font-medium text-ink/80 max-w-3xl mx-auto leading-relaxed"
-                >
-                    Gefeliciteerd, je hebt het einde van het internet bereikt.
-                </p>
-                <p
-                    class="text-base md:text-lg font-mono text-ink/60 max-w-md mx-auto"
-                >
-                    (Waarschijnlijk heb je een typefout gemaakt. Of wij hebben
-                    iets gesloopt. Laten we het er maar op houden dat het aan
-                    ons ligt.)
-                </p>
-            </div>
+				<p class="text-lg text-ink/60 max-w-sm mx-auto mb-12">
+					Kan gebeuren. Hier is de weg terug.
+				</p>
 
-            <!-- Quick Navigation -->
-            <div class="mt-12 w-full max-w-xl">
-                <p class="text-sm font-mono text-ink/60 uppercase tracking-widest mb-6">
-                    Misschien zoek je dit?
-                </p>
-                <div class="grid grid-cols-2 gap-3">
-                    <a
-                        href="/portfolio"
-                        class="group p-4 border border-ink/10 hover:border-ink hover:bg-ink hover:text-canvas transition-all duration-300 text-left"
-                    >
-                        <span class="font-bold uppercase tracking-tight text-sm">Portfolio</span>
-                        <span class="block text-xs text-ink/50 group-hover:text-canvas/60 mt-1">Bekijk ons werk</span>
-                    </a>
-                    <a
-                        href="/aanvragen"
-                        class="group p-4 border border-ink/10 hover:border-ink hover:bg-ink hover:text-canvas transition-all duration-300 text-left"
-                    >
-                        <span class="font-bold uppercase tracking-tight text-sm">Aanvragen</span>
-                        <span class="block text-xs text-ink/50 group-hover:text-canvas/60 mt-1">Start je project</span>
-                    </a>
-                    <a
-                        href="/website-laten-maken"
-                        class="group p-4 border border-ink/10 hover:border-ink hover:bg-ink hover:text-canvas transition-all duration-300 text-left"
-                    >
-                        <span class="font-bold uppercase tracking-tight text-sm">Diensten</span>
-                        <span class="block text-xs text-ink/50 group-hover:text-canvas/60 mt-1">Wat wij doen</span>
-                    </a>
-                    <a
-                        href="/contact"
-                        class="group p-4 border border-ink/10 hover:border-ink hover:bg-ink hover:text-canvas transition-all duration-300 text-left"
-                    >
-                        <span class="font-bold uppercase tracking-tight text-sm">Contact</span>
-                        <span class="block text-xs text-ink/50 group-hover:text-canvas/60 mt-1">Stel een vraag</span>
-                    </a>
-                </div>
-            </div>
-        </div>
-    </main>
-    <Footer />
+				<!-- Primary CTA -->
+				<a
+					href="/"
+					class="inline-flex items-center gap-3 bg-ink text-canvas px-8 py-4 font-bold uppercase tracking-tight hover:bg-acid hover:text-ink transition-colors duration-300 group mb-12"
+				>
+					<span>&larr;</span>
+					<span>Naar home</span>
+				</a>
+
+				<!-- Secondary Navigation -->
+				<div class="pt-8 border-t border-ink/10">
+					<p class="text-sm text-ink/60 mb-6">Of direct naar:</p>
+					<div class="flex flex-wrap justify-center gap-2">
+						<a
+							href="/portfolio"
+							class="px-4 py-2 text-sm font-medium text-ink/70 hover:text-ink hover:bg-ink/5 transition-colors"
+						>
+							Projecten
+						</a>
+						<a
+							href="/website-laten-maken"
+							class="px-4 py-2 text-sm font-medium text-ink/70 hover:text-ink hover:bg-ink/5 transition-colors"
+						>
+							Websites
+						</a>
+						<a
+							href="/automations"
+							class="px-4 py-2 text-sm font-medium text-ink/70 hover:text-ink hover:bg-ink/5 transition-colors"
+						>
+							Automations
+						</a>
+						<a
+							href="/contact"
+							class="px-4 py-2 text-sm font-medium text-ink/70 hover:text-ink hover:bg-ink/5 transition-colors"
+						>
+							Contact
+						</a>
+					</div>
+				</div>
+			</div>
+		</section>
+	</main>
+	<Footer />
 </Layout>


### PR DESCRIPTION
## Summary
- Redesigned 404 page to match friendly solo entrepreneur tone
- "Verkeerde afslag. Kan gebeuren. Hier is de weg terug."
- Clean centered layout with subtle 404 visual
- Removed agency vibes (uppercase headers, corporate copy)

## Changes
- Simplified layout with soft gradient background
- Deadpan, self-deprecating humor that fits the brand
- Correct navigation labels (Projecten, Websites, etc.)
- No em-dashes (per content SOP)

Closes #162

🤖 Generated with [Claude Code](https://claude.ai/code)