### PR TITLE
feat(typography): replace em dashes with natural punctuation ✨

### DIFF
--- a/src/components/OfferSection.astro
+++ b/src/components/OfferSection.astro
@@ -38,23 +38,23 @@
 
 				<ul class="space-y-3 mb-8 flex-grow text-sm">
 					<li class="flex items-start gap-2">
-						<span class="text-ink/60">—</span>
+						<span class="text-ink/60">•</span>
 						<span class="text-ink/70">Professioneel design op maat</span>
 					</li>
 					<li class="flex items-start gap-2">
-						<span class="text-ink/60">—</span>
+						<span class="text-ink/60">•</span>
 						<span class="text-ink/70">Teksten geschreven</span>
 					</li>
 					<li class="flex items-start gap-2">
-						<span class="text-ink/60">—</span>
+						<span class="text-ink/60">•</span>
 						<span class="text-ink/70">Mobiel-vriendelijk & razendsnel</span>
 					</li>
 					<li class="flex items-start gap-2">
-						<span class="text-ink/60">—</span>
+						<span class="text-ink/60">•</span>
 						<span class="text-ink/70">Hosting inbegrepen</span>
 					</li>
 					<li class="flex items-start gap-2">
-						<span class="text-ink/60">—</span>
+						<span class="text-ink/60">•</span>
 						<span class="text-ink/70">Automatische e-mail bevestiging</span>
 					</li>
 				</ul>
@@ -96,7 +96,7 @@
 
 				<ul class="space-y-3 mb-8 flex-grow text-sm">
 					<li class="flex items-start gap-2">
-						<span class="text-ink/50">—</span>
+						<span class="text-ink/50">•</span>
 						<span class="text-ink/80">Alles uit Start, plus:</span>
 					</li>
 					<li class="flex items-start gap-2">
@@ -149,7 +149,7 @@
 
 				<ul class="space-y-3 mb-8 flex-grow text-sm">
 					<li class="flex items-start gap-2">
-						<span class="text-canvas/40">—</span>
+						<span class="text-canvas/40">•</span>
 						<span class="text-canvas/60">Alles uit Slim, plus:</span>
 					</li>
 					<li class="flex items-start gap-2">

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -75,7 +75,7 @@ Ze onderscheiden zich met een Ladies Only zone, kickboks lessen en persoonlijke 
 In de fitnessbranche domineren grote ketens met dure marketingbudgetten de zoekresultaten. Een lokale sportschool moet slim omgaan met SEO: focussen op lokale zoekopdrachten, transparante prijzen tonen, en zich onderscheiden op persoonlijke service en community. De website moet bezoekers binnen seconden overtuigen: betaalbaar, betrouwbaar, dichtbij.`,
 		solution: `We creëerden een frisse, energieke website met oranje accenten die de toegankelijkheid benadrukt. Het strakke, no-nonsense ontwerp past bij de filosofie van de sportschool. Prijzen staan prominent op de homepage (vanaf €19,95/maand + €17 inschrijfgeld), openingstijden zijn direct zichtbaar, en de "Word Lid" knop is altijd binnen handbereik.
 
-Het ontwerp is mobile-first — 70% van potentiële leden zoekt vanaf hun telefoon. Click-to-call knoppen maken het makkelijk om direct te bellen. De USP's (Ladies Only, kickboks, gratis begeleiding) krijgen visueel de aandacht die ze verdienen. Geen eindeloos scrollen: bezoekers krijgen direct de informatie die ze zoeken.`,
+Het ontwerp is mobile-first: 70% van potentiële leden zoekt vanaf hun telefoon. Click-to-call knoppen maken het makkelijk om direct te bellen. De USP's (Ladies Only, kickboks, gratis begeleiding) krijgen visueel de aandacht die ze verdienen. Geen eindeloos scrollen: bezoekers krijgen direct de informatie die ze zoeken.`,
 		features: [
 			"Prominente prijsweergave vanaf €19,95/maand",
 			"Ladies Only zone highlight voor vrouwelijke doelgroep",
@@ -107,7 +107,7 @@ Het ontwerp is mobile-first — 70% van potentiële leden zoekt vanaf hun telefo
 			"Lokale SEO voor 'sportschool Culemborg' top 3",
 			"Transparante prijsweergave verhoogt conversie",
 		],
-		industryContext: "De fitnessbranche is competitief. Potentiële leden vergelijken sportscholen online voordat ze langskomen. Een professionele website met transparante prijzen en een simpel aanmeldproces verlaagt de drempel om lid te worden. Lokale SEO is essentieel: 76% van lokale zoekopdrachten leidt binnen 24 uur tot contact. Budget-sportscholen moeten vooral communiceren op prijs, toegankelijkheid en resultaat — niet op luxe.",
+		industryContext: "De fitnessbranche is competitief. Potentiële leden vergelijken sportscholen online voordat ze langskomen. Een professionele website met transparante prijzen en een simpel aanmeldproces verlaagt de drempel om lid te worden. Lokale SEO is essentieel: 76% van lokale zoekopdrachten leidt binnen 24 uur tot contact. Budget-sportscholen moeten vooral communiceren op prijs, toegankelijkheid en resultaat, niet op luxe.",
 	},
 	{
 		slug: "maatwerk-website-voor-by-shakir",
@@ -121,12 +121,12 @@ Het ontwerp is mobile-first — 70% van potentiële leden zoekt vanaf hun telefo
 		overviewMockup: "/assets/projects/mockups/byshakir.webp",
 		link: "https://byshakir.knapgemaakt.nl",
 		shortDescription: "Geen meubelwinkel. Een designautoriteit.",
-		fullDescription: `By Shakir | Metropolitan Luxury is geen meubelwinkel — het is een design autoriteit. Opgericht vanuit de missie om de Nederlandse markt iets anders te bieden dan standaard meubels. "Ik zag een gat in de markt. Overal meubelzaken die producten verkopen, maar niemand die visies verkocht," aldus oprichter Shakir.
+		fullDescription: `By Shakir | Metropolitan Luxury is geen meubelwinkel, het is een design autoriteit. Opgericht vanuit de missie om de Nederlandse markt iets anders te bieden dan standaard meubels. "Ik zag een gat in de markt. Overal meubelzaken die producten verkopen, maar niemand die visies verkocht," aldus oprichter Shakir.
 
-Met meer dan 15 jaar ervaring creëert By Shakir complete interieurconcepten die brutalistisch architectonische elegantie combineren met de warmte van high-end hospitality. Van fotorealistische 3D-visualisatie tot volledige turnkey projectmanagement. Hun klanten zijn niet op zoek naar een bank — ze zoeken een ervaring, een verhaal, een ruimte die emotioneel resoneert.`,
+Met meer dan 15 jaar ervaring creëert By Shakir complete interieurconcepten die brutalistisch architectonische elegantie combineren met de warmte van high-end hospitality. Van fotorealistische 3D-visualisatie tot volledige turnkey projectmanagement. Hun klanten zijn niet op zoek naar een bank. Ze zoeken een ervaring, een verhaal, een ruimte die emotioneel resoneert.`,
 		challenge: `By Shakir wilde zich nadrukkelijk onderscheiden van de massa meubelretailers. De challenge: een website die "design authority" communiceert, niet "meubelwinkel". De internationale klantenkring (Nederland, België, Marokko) vraagt om een online presentatie die het niveau van hun fysieke showroom in Tiel evenaart.
 
-In het premium interieur segment is de website vaak het eerste contactmoment. Klanten die investeren in maatwerk interieurs verwachten geen standaard WordPress template. De uitdaging was een digitale ervaring te creëren die de merkpositie "Metropolitan Luxury" onderstreept, waarbij elk detail — van typografie tot animaties — de premiumpositionering communiceert.`,
+In het premium interieur segment is de website vaak het eerste contactmoment. Klanten die investeren in maatwerk interieurs verwachten geen standaard WordPress template. De uitdaging was een digitale ervaring te creëren die de merkpositie "Metropolitan Luxury" onderstreept, waarbij elk detail (van typografie tot animaties) de premiumpositionering communiceert.`,
 		solution: `We ontwierpen een website met een donker, luxueus kleurenpalet (zwart, bruin, goud) dat past bij hun "brutalistisch met warmte" filosofie. Grote, cinematografische beelden van hun projecten staan centraal. De headline "Refining Living Spaces" zet direct de toon.
 
 Belangrijkste ontwerpbeslissingen:

--- a/src/pages/automations.astro
+++ b/src/pages/automations.astro
@@ -248,7 +248,7 @@ const steps = [
 			</div>
 		</section>
 
-		<!-- SECTION 3: WHAT'S POSSIBLE — before/after (light) -->
+		<!-- SECTION 3: WHAT'S POSSIBLE - before/after (light) -->
 		<section class="py-16 md:py-24 px-6 md:px-12 lg:px-16 bg-canvas bg-grid-light relative overflow-hidden">
 			<div class="max-w-6xl xl:max-w-7xl mx-auto">
 				<div class="text-xs font-mono uppercase tracking-[0.2em] text-ink/60 mb-6">
@@ -313,7 +313,7 @@ const steps = [
 							<ul class="space-y-2 text-canvas/50 text-sm">
 								{step.details.map((detail) => (
 									<li class="flex items-start gap-2">
-										<span class="text-acid mt-0.5 shrink-0">—</span>
+										<span class="text-acid mt-0.5 shrink-0">•</span>
 										<span>{detail}</span>
 									</li>
 								))}

--- a/src/pages/project/[slug].astro
+++ b/src/pages/project/[slug].astro
@@ -227,7 +227,7 @@ const pageTitle = `Maatwerk website voor ${project.title} | ${project.industry}`
 						"{project.testimonial.quote}"
 					</blockquote>
 					<div class="text-acid font-mono text-sm uppercase tracking-wider">
-						— {project.testimonial.author}
+						{project.testimonial.author}
 					</div>
 					<div class="text-canvas/60 font-mono text-xs uppercase tracking-wider mt-2">
 						{project.testimonial.role}

--- a/src/pages/website-laten-maken.astro
+++ b/src/pages/website-laten-maken.astro
@@ -206,27 +206,27 @@ const faqs = [
 
 						<ul class="space-y-3 mb-8 flex-grow">
 							<li class="flex items-start gap-3">
-								<span class="text-ink/60 mt-0.5">—</span>
+								<span class="text-ink/60 mt-0.5">•</span>
 								<span class="text-ink/70">Website op maat, geen templates</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-ink/60 mt-0.5">—</span>
+								<span class="text-ink/60 mt-0.5">•</span>
 								<span class="text-ink/70">Teksten inbegrepen (of eigen teksten)</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-ink/60 mt-0.5">—</span>
+								<span class="text-ink/60 mt-0.5">•</span>
 								<span class="text-ink/70">Mobiel-vriendelijk & razendsnel</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-ink/60 mt-0.5">—</span>
+								<span class="text-ink/60 mt-0.5">•</span>
 								<span class="text-ink/70">SEO-basis & Google vindbaar</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-ink/60 mt-0.5">—</span>
+								<span class="text-ink/60 mt-0.5">•</span>
 								<span class="text-ink/70">Contactformulier met e-mail bevestiging</span>
 							</li>
 							<li class="flex items-start gap-3">
-								<span class="text-ink/60 mt-0.5">—</span>
+								<span class="text-ink/60 mt-0.5">•</span>
 								<span class="text-ink/70">Hosting via Cloudflare inbegrepen</span>
 							</li>
 						</ul>
@@ -268,7 +268,7 @@ const faqs = [
 
 						<ul class="space-y-3 mb-8 flex-grow">
 							<li class="flex items-start gap-3">
-								<span class="text-ink/50 mt-0.5">—</span>
+								<span class="text-ink/50 mt-0.5">•</span>
 								<span class="text-ink/80">Alles uit Website, plus:</span>
 							</li>
 							<li class="flex items-start gap-3">
@@ -469,19 +469,19 @@ const faqs = [
 						</p>
 						<ul class="space-y-2 text-canvas/60 text-sm">
 							<li class="flex items-start gap-2">
-								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span class="text-acid mt-0.5 shrink-0">•</span>
 								<span>Wat je doet en wie je klanten zijn</span>
 							</li>
 							<li class="flex items-start gap-2">
-								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span class="text-acid mt-0.5 shrink-0">•</span>
 								<span>Wat je website voor je moet doen: meer aanvragen, afspraken, bekendheid?</span>
 							</li>
 							<li class="flex items-start gap-2">
-								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span class="text-acid mt-0.5 shrink-0">•</span>
 								<span>Of je al een website hebt en wat daar wel of niet werkt</span>
 							</li>
 							<li class="flex items-start gap-2">
-								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span class="text-acid mt-0.5 shrink-0">•</span>
 								<span>Wat je mooi vindt: websites die je aanspreken, kleuren, stijl</span>
 							</li>
 						</ul>
@@ -501,15 +501,15 @@ const faqs = [
 						</p>
 						<ul class="space-y-2 text-canvas/60 text-sm">
 							<li class="flex items-start gap-2">
-								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span class="text-acid mt-0.5 shrink-0">•</span>
 								<span>Je logo (als je dat hebt)</span>
 							</li>
 							<li class="flex items-start gap-2">
-								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span class="text-acid mt-0.5 shrink-0">•</span>
 								<span>Foto's van je werk, team of bedrijf</span>
 							</li>
 							<li class="flex items-start gap-2">
-								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span class="text-acid mt-0.5 shrink-0">•</span>
 								<span>Toegang tot je domeinnaam, of ik regel een nieuw domein</span>
 							</li>
 						</ul>
@@ -529,19 +529,19 @@ const faqs = [
 						</p>
 						<ul class="space-y-2 text-canvas/60 text-sm">
 							<li class="flex items-start gap-2">
-								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span class="text-acid mt-0.5 shrink-0">•</span>
 								<span>Concurrentie-analyse: wat doen anderen in jouw markt?</span>
 							</li>
 							<li class="flex items-start gap-2">
-								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span class="text-acid mt-0.5 shrink-0">•</span>
 								<span>Design: een ontwerp dat past bij jouw bedrijf</span>
 							</li>
 							<li class="flex items-start gap-2">
-								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span class="text-acid mt-0.5 shrink-0">•</span>
 								<span>Teksten: geschreven om klanten aan te spreken</span>
 							</li>
 							<li class="flex items-start gap-2">
-								<span class="text-acid mt-0.5 shrink-0">—</span>
+								<span class="text-acid mt-0.5 shrink-0">•</span>
 								<span>Techniek: snel, veilig en vindbaar in Google</span>
 							</li>
 						</ul>


### PR DESCRIPTION
## Summary
- Replace em dash list markers (—) with bullets (•) in pricing tables and feature lists
- Rewrite project descriptions using natural Dutch punctuation (commas, colons, periods)
- Simplify testimonial attribution by removing leading em dash

## Changes
| File | Changes |
|------|---------|
| `OfferSection.astro` | 7 em dashes → bullets |
| `website-laten-maken.astro` | 20 em dashes → bullets |
| `automations.astro` | 2 em dashes → bullets |
| `projects.ts` | 5 content rewrites |
| `project/[slug].astro` | 1 attribution simplified |

## Why
Em dashes are commonly associated with AI-generated content and feel overly formal in Dutch. Natural punctuation improves authenticity and readability.

Closes #170

🤖 Generated with [Claude Code](https://claude.ai/claude-code)