### PR TITLE
fix(forms): fix contact form View Transitions and add email error logging 🐛

### DIFF
--- a/src/pages/api/submissions.ts
+++ b/src/pages/api/submissions.ts
@@ -177,7 +177,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
             subject = 'Nieuwe website-audit aanvraag';
           }
 
-          await fetch('https://api.resend.com/emails', {
+          const emailResponse = await fetch('https://api.resend.com/emails', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -191,6 +191,11 @@ export const POST: APIRoute = async ({ request, locals }) => {
               html: emailHtml
             })
           });
+
+          if (!emailResponse.ok) {
+            const errorData = await emailResponse.json().catch(() => ({}));
+            console.error('[Submissions API] Resend API error:', emailResponse.status, errorData);
+          }
         } catch (err) {
           console.error('[Submissions API] Failed to send email:', err);
         }

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -308,9 +308,9 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 </Layout>
 
 <script>
-	(function() {
+	function initContactForm() {
 		const form = document.getElementById('contact-form') as HTMLFormElement;
-		if (!form) return;
+		if (!form || form.dataset.listenerAttached) return;
 
 		form.addEventListener('submit', async (e) => {
 			e.preventDefault();
@@ -369,5 +369,13 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 				btnLoading?.classList.add('hidden');
 			}
 		});
-	})();
+
+		form.dataset.listenerAttached = 'true';
+	}
+
+	// Initialize on first load
+	initContactForm();
+
+	// Re-initialize after View Transitions
+	document.addEventListener('astro:page-load', initContactForm);
 </script>


### PR DESCRIPTION
## Summary
- Contact form now re-initializes after View Transitions navigation (was using IIFE that only ran once)
- Add Resend API response error logging for debugging email delivery issues

## Root cause
The contact form used an IIFE that only ran on initial page load. When navigating via View Transitions, the JavaScript didn't re-attach, causing traditional form submission (page reload, no API call).

## What's still uncertain
Email delivery for audit/offerte forms needs investigation:
- Check if `RESEND_API_KEY` is set in Cloudflare Pages environment
- Check logs for `[Submissions API] Resend API error:` messages

Closes #174

🤖 Generated with [Claude Code](https://claude.ai/code)