### PR TITLE
feat(forms): add privacy consent checkbox to audit form ✨

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -259,7 +259,7 @@ const projects = getAllProjects();
 							placeholder="E-mailadres"
 						/>
 					</div>
-					<div class="flex flex-col sm:flex-row gap-3">
+					<div class="flex flex-col sm:flex-row gap-3 mb-3">
 						<input
 							type="text"
 							id="audit-website"
@@ -274,6 +274,22 @@ const projects = getAllProjects();
 						>
 							Check mijn website
 						</button>
+					</div>
+
+					<!-- Privacy checkbox -->
+					<div class="flex items-start gap-3">
+						<input
+							type="checkbox"
+							id="audit-privacy"
+							name="privacy"
+							required
+							oninvalid="this.setCustomValidity('Je moet akkoord gaan met de privacyverklaring')"
+							oninput="this.setCustomValidity('')"
+							class="mt-1 w-4 h-4 shrink-0 accent-electric"
+						/>
+						<label for="audit-privacy" class="text-sm text-ink/60">
+							Ik ga akkoord met de <a href="/privacy" class="underline hover:text-ink transition-colors">privacyverklaring</a>
+						</label>
 					</div>
 				</form>
 			</div>


### PR DESCRIPTION
## Summary
- Adds GDPR-compliant privacy consent checkbox to the free website audit form
- Uses existing pattern from contact/aanvragen/automations forms
- Dutch validation message: "Je moet akkoord gaan met de privacyverklaring"

## Test plan
- [ ] Visit homepage and scroll to audit form
- [ ] Try submitting without checking the box → should show Dutch error
- [ ] Check the box and submit → should work as before

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)