### PR TITLE
fix(forms): move privacy checkbox before submit button 🐛

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -290,7 +290,7 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 							<p class="font-bold uppercase tracking-tight">Adres</p>
 							<p class="text-ink/60 text-sm">
 								Françoise de Lanoistraat 9<br />
-								4116 BH Buren
+								4116 ET Buren
 							</p>
 						</div>
 					</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -268,16 +268,10 @@ const projects = getAllProjects();
 							class="flex-1 px-4 py-4 bg-canvas border-2 border-ink/10 text-ink placeholder-ink/40 focus:border-ink focus:outline-none transition-colors"
 							placeholder="jouwwebsite.nl"
 						/>
-						<button
-							type="submit"
-							class="bg-ink text-canvas px-8 py-4 font-bold uppercase tracking-tight hover:bg-acid hover:text-ink transition-colors duration-300 whitespace-nowrap cursor-pointer"
-						>
-							Check mijn website
-						</button>
 					</div>
 
 					<!-- Privacy checkbox -->
-					<div class="flex items-start gap-3">
+					<div class="flex items-start gap-3 mb-3">
 						<input
 							type="checkbox"
 							id="audit-privacy"
@@ -291,6 +285,13 @@ const projects = getAllProjects();
 							Ik ga akkoord met de <a href="/privacy" class="underline hover:text-ink transition-colors">privacyverklaring</a>
 						</label>
 					</div>
+
+					<button
+						type="submit"
+						class="w-full sm:w-auto bg-ink text-canvas px-8 py-4 font-bold uppercase tracking-tight hover:bg-acid hover:text-ink transition-colors duration-300 whitespace-nowrap cursor-pointer"
+					>
+						Check mijn website
+					</button>
 				</form>
 			</div>
 		</section>


### PR DESCRIPTION
## Summary

- Reorders the audit form on the homepage so the privacy consent checkbox appears **before** the submit button (GDPR compliance)
- Fixes incorrect postal code on contact page (4116 BH → 4116 ET)

Closes #183

## Test plan

- [ ] Visit homepage and verify checkbox appears above "Check mijn website" button
- [ ] Test form submission still works correctly
- [ ] Verify postal code shows "4116 ET Buren" on contact page

🤖 Generated with [Claude Code](https://claude.ai/code)