### PR TITLE
fix(sitemap): add 3 missing blog posts

### DIFF
--- a/src/data/blog.ts
+++ b/src/data/blog.ts
@@ -21,6 +21,21 @@ export const blogPosts: BlogPostMeta[] = [
 		title: "iDEAL wordt Wero: Wat betekent dit voor jouw webshop?",
 		publishDate: "2026-01-29",
 	},
+	{
+		slug: "wero-webshops-checklist-maart",
+		title: "Wero voor webshops: 5 dingen die je voor 31 maart moet regelen",
+		publishDate: "2026-01-30",
+	},
+	{
+		slug: "wero-kosten-transactiekosten",
+		title: "Wat kost Wero? Transactiekosten voor ondernemers uitgelegd",
+		publishDate: "2026-01-31",
+	},
+	{
+		slug: "wero-mollie-integratie",
+		title: "Wero en Mollie: Hoe werkt de integratie?",
+		publishDate: "2026-02-01",
+	},
 ];
 
 export function getAllBlogPosts(): BlogPostMeta[] {


### PR DESCRIPTION
## Summary
- Added 3 missing blog posts to `src/data/blog.ts` for sitemap generation
- Posts added: `wero-kosten-transactiekosten`, `wero-webshops-checklist-maart`, `wero-mollie-integratie`

Closes #188

## Test plan
- [ ] Verify https://knapgemaakt.nl/sitemap.xml includes all 4 blog posts after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)