### PR TITLE
fix: align trailing slash config with Cloudflare behavior

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,7 +8,7 @@ import cloudflare from '@astrojs/cloudflare';
 // https://astro.build/config
 export default defineConfig({
   site: "https://knapgemaakt.nl",
-  trailingSlash: "never",
+  trailingSlash: "always",
   output: 'server', // Server-side rendering with Cloudflare Workers
   adapter: cloudflare({
     platformProxy: {

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -17,20 +17,20 @@ function generateSitemap(): string {
 
     const staticPages: PageEntry[] = [
         { path: "/", lastmod: today, changefreq: "weekly", priority: "1.0" },
-        { path: "/website-laten-maken", lastmod: today, changefreq: "weekly", priority: "0.9" },
-        { path: "/aanvragen", lastmod: today, changefreq: "monthly", priority: "0.9" },
-        { path: "/automations", lastmod: today, changefreq: "monthly", priority: "0.8" },
-        { path: "/portfolio", lastmod: today, changefreq: "weekly", priority: "0.8" },
-        { path: "/blog", lastmod: today, changefreq: "weekly", priority: "0.8" },
-        { path: "/contact", lastmod: today, changefreq: "monthly", priority: "0.7" },
-        { path: "/over-mij", lastmod: today, changefreq: "monthly", priority: "0.6" },
-        { path: "/algemene-voorwaarden", lastmod: "2026-01-20", changefreq: "yearly", priority: "0.3" },
-        { path: "/privacy", lastmod: "2026-01-20", changefreq: "yearly", priority: "0.3" },
+        { path: "/website-laten-maken/", lastmod: today, changefreq: "weekly", priority: "0.9" },
+        { path: "/aanvragen/", lastmod: today, changefreq: "monthly", priority: "0.9" },
+        { path: "/automations/", lastmod: today, changefreq: "monthly", priority: "0.8" },
+        { path: "/portfolio/", lastmod: today, changefreq: "weekly", priority: "0.8" },
+        { path: "/blog/", lastmod: today, changefreq: "weekly", priority: "0.8" },
+        { path: "/contact/", lastmod: today, changefreq: "monthly", priority: "0.7" },
+        { path: "/over-mij/", lastmod: today, changefreq: "monthly", priority: "0.6" },
+        { path: "/algemene-voorwaarden/", lastmod: "2026-01-20", changefreq: "yearly", priority: "0.3" },
+        { path: "/privacy/", lastmod: "2026-01-20", changefreq: "yearly", priority: "0.3" },
     ];
 
     // Dynamically generate project pages from data
     const projectPages: PageEntry[] = getAllProjects().map((project) => ({
-        path: `/project/${project.slug}`,
+        path: `/project/${project.slug}/`,
         lastmod: today,
         changefreq: "monthly" as const,
         priority: "0.7",
@@ -38,7 +38,7 @@ function generateSitemap(): string {
 
     // Dynamically generate city pages from data
     const cityPages: PageEntry[] = getAllCities().map((city) => ({
-        path: `/webdesign-${city.slug}`,
+        path: `/webdesign-${city.slug}/`,
         lastmod: today,
         changefreq: "weekly" as const,
         priority: "0.8",
@@ -46,7 +46,7 @@ function generateSitemap(): string {
 
     // Dynamically generate blog post pages from data
     const blogPages: PageEntry[] = getAllBlogPosts().map((post) => ({
-        path: `/blog/${post.slug}`,
+        path: `/blog/${post.slug}/`,
         lastmod: post.publishDate,
         changefreq: "monthly" as const,
         priority: "0.7",


### PR DESCRIPTION
## Summary
- Changed `trailingSlash` from `"never"` to `"always"` in Astro config
- Updated all sitemap URLs to include trailing slashes
- Fixes Google Search Console redirect errors (308 redirects)

## Problem
Cloudflare Workers adds trailing slashes to prerendered pages (e.g., `/blog/post` → `/blog/post/`), but Astro was configured with `trailingSlash: "never"`. This mismatch caused Google to report redirect errors for 6 pages.

## Test plan
- [x] Build succeeds
- [ ] Verify sitemap URLs have trailing slashes after deploy
- [ ] Monitor Google Search Console for resolved redirect errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)