### PR TITLE
fix(seo): add trailing slashes to all internal links 🐛

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -42,14 +42,14 @@ const regionOrder = ["Rivierenland", "Regio Utrecht", "Noord-Brabant", "Gelderla
 			</p>
 			<div class="flex flex-col sm:flex-row items-center justify-center gap-4">
 				<a
-					href="/aanvragen"
+					href="/aanvragen/"
 					class="bg-acid text-ink px-8 py-[18px] font-bold uppercase tracking-tight hover:bg-canvas hover:text-ink transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 				>
 					Plan een gesprek in
 					<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 				</a>
 				<a
-					href="/contact"
+					href="/contact/"
 					class="bg-canvas text-ink px-8 py-[18px] font-bold uppercase tracking-tight hover:bg-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
 				>
 					Neem contact op
@@ -77,7 +77,7 @@ const regionOrder = ["Rivierenland", "Regio Utrecht", "Noord-Brabant", "Gelderla
 							<div class="flex flex-col gap-1.5">
 								{cityGroups[region].map((city) => (
 									<a
-										href={`/webdesign-${city.slug}`}
+										href={`/webdesign-${city.slug}/`}
 										class="text-sm text-canvas/60 hover:text-acid transition-colors"
 									>
 										{city.name}
@@ -102,10 +102,10 @@ const regionOrder = ["Rivierenland", "Regio Utrecht", "Noord-Brabant", "Gelderla
 		<div class="pt-8 border-t border-canvas/10">
 			<!-- Legal Links -->
 			<div class="flex flex-wrap justify-center md:justify-start gap-x-6 gap-y-2 font-mono text-xs text-canvas/50 uppercase tracking-widest mb-6">
-				<a href="/contact" class="hover:text-acid transition-colors">Contact</a>
-				<a href="/algemene-voorwaarden" class="hover:text-acid transition-colors">Voorwaarden</a>
-				<a href="/privacy" class="hover:text-acid transition-colors">Privacy</a>
-				<a href="/sitemap" class="hover:text-acid transition-colors">Sitemap</a>
+				<a href="/contact/" class="hover:text-acid transition-colors">Contact</a>
+				<a href="/algemene-voorwaarden/" class="hover:text-acid transition-colors">Voorwaarden</a>
+				<a href="/privacy/" class="hover:text-acid transition-colors">Privacy</a>
+				<a href="/sitemap/" class="hover:text-acid transition-colors">Sitemap</a>
 				<button
 					type="button"
 					id="cookie-settings-trigger"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -13,12 +13,12 @@ const { variant = "default" } = Astro.props;
 const currentPath = Astro.url.pathname;
 
 const navLinks = [
-    { href: "/website-laten-maken", label: "Websites" },
-    { href: "/automations", label: "Automations" },
-    { href: "/portfolio", label: "Projecten" },
-    { href: "/blog", label: "Kennis" },
-    { href: "/over-mij", label: "Over Mij" },
-    { href: "/contact", label: "Contact" },
+    { href: "/website-laten-maken/", label: "Websites" },
+    { href: "/automations/", label: "Automations" },
+    { href: "/portfolio/", label: "Projecten" },
+    { href: "/blog/", label: "Kennis" },
+    { href: "/over-mij/", label: "Over Mij" },
+    { href: "/contact/", label: "Contact" },
 ];
 
 const isActive = (href: string) => {
@@ -60,7 +60,7 @@ const isActive = (href: string) => {
                     </a>
                 ))}
                 <a
-                    href="/contact"
+                    href="/contact/"
                     class="border border-ink/30 text-ink px-5 py-2.5 font-bold uppercase tracking-tight text-sm hover:border-ink hover:bg-ink hover:text-canvas transition-all duration-300"
                 >
                     Stuur Bericht
@@ -121,7 +121,7 @@ const isActive = (href: string) => {
 
         <!-- CTA Button -->
         <a
-            href="/aanvragen"
+            href="/aanvragen/"
             class="mobile-nav-cta group relative mt-12 overflow-hidden"
             style={`--index: ${navLinks.length}`}
         >

--- a/src/components/LocalSEOSection.astro
+++ b/src/components/LocalSEOSection.astro
@@ -266,14 +266,14 @@ function getAreaLink(areaName: string): string | null {
 							{relatedProject.shortDescription}
 						</p>
 						<a
-							href={`/project/${relatedProject.slug}`}
+							href={`/project/${relatedProject.slug}/`}
 							class="text-electric font-mono text-sm uppercase tracking-wider hover:text-ink transition-colors inline-flex items-center gap-2 group"
 						>
 							<span>Bekijk Case Study</span>
 							<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 						</a>
 					</div>
-					<a href={`/project/${relatedProject.slug}`} class="relative aspect-video overflow-hidden bg-ink/5 block group">
+					<a href={`/project/${relatedProject.slug}/`} class="relative aspect-video overflow-hidden bg-ink/5 block group">
 						<img
 							src={relatedProject.image}
 							alt={`${relatedProject.title} website voorbeeld`}

--- a/src/components/OfferLocalSEOSection.astro
+++ b/src/components/OfferLocalSEOSection.astro
@@ -187,7 +187,7 @@ function getAreaLink(areaName: string): string | null {
 
                     {city.coffeeLocation && (
                         <a
-                            href="/aanvragen"
+                            href="/aanvragen/"
                             class="inline-flex items-center gap-3 text-electric font-mono text-sm uppercase tracking-wider hover:text-ink transition-colors group"
                         >
                             <span>{city.coffeeLocation}</span>
@@ -276,14 +276,14 @@ function getAreaLink(areaName: string): string | null {
                                 {relatedProject.shortDescription}
                             </p>
                             <a
-                                href={`/project/${relatedProject.slug}`}
+                                href={`/project/${relatedProject.slug}/`}
                                 class="text-electric font-mono text-sm uppercase tracking-wider hover:text-ink transition-colors inline-flex items-center gap-2 group"
                             >
                                 <span>Bekijk Case Study</span>
                                 <span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
                             </a>
                         </div>
-                        <a href={`/project/${relatedProject.slug}`} class="relative aspect-video overflow-hidden bg-ink/5 block group">
+                        <a href={`/project/${relatedProject.slug}/`} class="relative aspect-video overflow-hidden bg-ink/5 block group">
                             <img
                                 src={relatedProject.overviewMockup || relatedProject.heroMockup || relatedProject.image}
                                 alt={`${relatedProject.title} website voorbeeld`}

--- a/src/components/OfferSection.astro
+++ b/src/components/OfferSection.astro
@@ -67,7 +67,7 @@
 				</div>
 
 				<a
-					href="/aanvragen"
+					href="/aanvragen/"
 					class="w-full bg-ink/10 border border-ink/20 text-ink py-3 font-bold uppercase tracking-tight text-sm hover:bg-ink hover:text-canvas transition-colors duration-300 text-center"
 				>
 					Kies Start
@@ -125,7 +125,7 @@
 				</div>
 
 				<a
-					href="/aanvragen"
+					href="/aanvragen/"
 					class="w-full bg-ink text-acid py-3 font-bold uppercase tracking-tight text-sm hover:bg-acid hover:text-ink transition-colors duration-300 text-center"
 				>
 					Kies Slim
@@ -178,7 +178,7 @@
 				</div>
 
 				<a
-					href="/aanvragen"
+					href="/aanvragen/"
 					class="w-full bg-acid text-ink py-3 font-bold uppercase tracking-tight text-sm hover:bg-canvas hover:text-ink transition-colors duration-300 text-center"
 				>
 					Kies Systeem

--- a/src/components/PortfolioSection.astro
+++ b/src/components/PortfolioSection.astro
@@ -24,7 +24,7 @@ const featured = getShowcaseProject();
 		{featured && (
 			<div class="space-y-12">
 				<!-- Showcase Mockup - Full Width -->
-				<a href={`/project/${featured.slug}`} class="block group">
+				<a href={`/project/${featured.slug}/`} class="block group">
 					<img
 						src={featured.showcaseMockup || featured.image}
 						alt={`${featured.title} website voorbeeld - desktop en mobiele weergave`}
@@ -72,7 +72,7 @@ const featured = getShowcaseProject();
 							<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 						</a>
 						<a
-							href={`/project/${featured.slug}`}
+							href={`/project/${featured.slug}/`}
 							class="w-full sm:w-auto border-2 border-canvas text-canvas px-8 py-[18px] font-bold uppercase tracking-tight hover:bg-canvas hover:text-ink transition-colors duration-300 text-center"
 						>
 							Case Study
@@ -83,7 +83,7 @@ const featured = getShowcaseProject();
 				<!-- View All Link -->
 				<div class="pt-8 border-t border-canvas/10">
 					<a
-						href="/portfolio"
+						href="/portfolio/"
 						class="text-acid font-mono text-sm uppercase tracking-wider hover:text-canvas transition-colors inline-flex items-center gap-2 group"
 					>
 						<span>Bekijk alle projecten</span>

--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -27,7 +27,7 @@ const estimatedReadingTime = readingTime || 5;
 ---
 
 <article class="group">
-	<a href={`/blog/${slug}`} class="block py-6 border-b border-ink/10 hover:border-ink/20 transition-colors">
+	<a href={`/blog/${slug}/`} class="block py-6 border-b border-ink/10 hover:border-ink/20 transition-colors">
 		<div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
 			<div class="flex-1 min-w-0">
 				<!-- Title -->

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -39,25 +39,25 @@ import Footer from "../components/Footer.astro";
 					<p class="text-sm text-ink/60 mb-6">Of direct naar:</p>
 					<div class="flex flex-wrap justify-center gap-2">
 						<a
-							href="/portfolio"
+							href="/portfolio/"
 							class="px-4 py-2 text-sm font-medium text-ink/70 hover:text-ink hover:bg-ink/5 transition-colors"
 						>
 							Projecten
 						</a>
 						<a
-							href="/website-laten-maken"
+							href="/website-laten-maken/"
 							class="px-4 py-2 text-sm font-medium text-ink/70 hover:text-ink hover:bg-ink/5 transition-colors"
 						>
 							Websites
 						</a>
 						<a
-							href="/automations"
+							href="/automations/"
 							class="px-4 py-2 text-sm font-medium text-ink/70 hover:text-ink hover:bg-ink/5 transition-colors"
 						>
 							Automations
 						</a>
 						<a
-							href="/contact"
+							href="/contact/"
 							class="px-4 py-2 text-sm font-medium text-ink/70 hover:text-ink hover:bg-ink/5 transition-colors"
 						>
 							Contact

--- a/src/pages/aanvragen.astro
+++ b/src/pages/aanvragen.astro
@@ -18,7 +18,7 @@ import Footer from "../components/Footer.astro";
                         class="text-5xl md:text-8xl font-black uppercase tracking-tight leading-none"
                     />
                     <a
-                        href="/contact"
+                        href="/contact/"
                         class="text-sm font-mono text-ink/60 hover:text-electric transition-colors whitespace-nowrap self-start md:self-auto md:mt-4"
                     >
                         Liever direct contact? &rarr;
@@ -332,7 +332,7 @@ import Footer from "../components/Footer.astro";
                         class="mt-1 w-4 h-4 shrink-0 accent-electric"
                     />
                     <label for="aanvraag-privacy" class="text-sm text-ink/60">
-                        Ik ga akkoord met de <a href="/privacy" class="underline hover:text-ink transition-colors">privacyverklaring</a>
+                        Ik ga akkoord met de <a href="/privacy/" class="underline hover:text-ink transition-colors">privacyverklaring</a>
                     </label>
                 </div>
 

--- a/src/pages/algemene-voorwaarden.astro
+++ b/src/pages/algemene-voorwaarden.astro
@@ -345,7 +345,7 @@ import Footer from "../components/Footer.astro";
 
                             <p class="mt-4"><strong class="text-ink">Google Calendar koppeling</strong></p>
                             <p>
-                                Door gebruik te maken van de agenda-synchronisatie geef je KNAP GEMAAKT. toestemming om je Google Agenda te lezen. Afspraken worden gebruikt om beschikbaarheid op je website te tonen. De verwerking vindt plaats conform ons <a href="/privacy#automatisering" class="text-ink underline decoration-acid decoration-2 underline-offset-4 hover:bg-acid hover:decoration-transparent transition-colors">privacybeleid</a>.
+                                Door gebruik te maken van de agenda-synchronisatie geef je KNAP GEMAAKT. toestemming om je Google Agenda te lezen. Afspraken worden gebruikt om beschikbaarheid op je website te tonen. De verwerking vindt plaats conform ons <a href="/privacy/#automatisering" class="text-ink underline decoration-acid decoration-2 underline-offset-4 hover:bg-acid hover:decoration-transparent transition-colors">privacybeleid</a>.
                             </p>
 
                             <p class="mt-4"><strong class="text-ink">Verantwoordelijkheid</strong></p>

--- a/src/pages/automations.astro
+++ b/src/pages/automations.astro
@@ -436,7 +436,7 @@ const steps = [
 							class="mt-1 w-4 h-4 shrink-0 accent-electric"
 						/>
 						<label for="auto-privacy" class="text-sm text-ink/60">
-							Ik ga akkoord met de <a href="/privacy" class="underline hover:text-ink transition-colors">privacyverklaring</a>
+							Ik ga akkoord met de <a href="/privacy/" class="underline hover:text-ink transition-colors">privacyverklaring</a>
 						</label>
 					</div>
 

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -78,7 +78,7 @@ const breadcrumbs = [
 				<div class="max-w-2xl mx-auto">
 					<!-- Back Link -->
 					<a
-						href="/blog"
+						href="/blog/"
 						class="inline-flex items-center gap-2 text-ink/40 hover:text-ink text-sm mb-8 transition-colors"
 					>
 						<span>&larr;</span>
@@ -108,7 +108,7 @@ const breadcrumbs = [
 
 					<!-- Author & Meta -->
 					<div class="flex items-center gap-4 pt-6 border-t border-ink/10">
-						<a href="/over-mij" class="flex-shrink-0">
+						<a href="/over-mij/" class="flex-shrink-0">
 							<img
 								src="/assets/yannick.webp"
 								alt="Yannick Veldhuisen"
@@ -120,7 +120,7 @@ const breadcrumbs = [
 							/>
 						</a>
 						<div>
-							<a href="/over-mij" class="font-semibold text-ink hover:text-ink/70 transition-colors">
+							<a href="/over-mij/" class="font-semibold text-ink hover:text-ink/70 transition-colors">
 								{post.data.author}
 							</a>
 							<div class="flex flex-wrap items-center gap-2 text-sm text-ink/50">
@@ -170,7 +170,7 @@ const breadcrumbs = [
 			<section class="px-6 md:px-12 lg:px-16 py-12 bg-ink/[0.02] border-y border-ink/10">
 				<div class="max-w-2xl mx-auto">
 					<div class="flex items-start gap-4">
-						<a href="/over-mij" class="flex-shrink-0">
+						<a href="/over-mij/" class="flex-shrink-0">
 							<img
 								src="/assets/yannick.webp"
 								alt="Yannick Veldhuisen"
@@ -183,7 +183,7 @@ const breadcrumbs = [
 						</a>
 						<div>
 							<p class="text-xs font-medium text-ink/40 uppercase tracking-wider mb-1">Geschreven door</p>
-							<a href="/over-mij" class="font-bold text-lg mb-2 block hover:text-ink/70 transition-colors">
+							<a href="/over-mij/" class="font-bold text-lg mb-2 block hover:text-ink/70 transition-colors">
 								{post.data.author}
 							</a>
 							<p class="text-ink/60 leading-relaxed">
@@ -208,7 +208,7 @@ const breadcrumbs = [
 									day: "numeric",
 								});
 								return (
-									<a href={`/blog/${otherPost.slug}`} class="group block py-4 border-b border-ink/10 hover:border-ink/20 transition-colors">
+									<a href={`/blog/${otherPost.slug}/`} class="group block py-4 border-b border-ink/10 hover:border-ink/20 transition-colors">
 										<h3 class="text-lg font-semibold text-ink leading-tight mb-2 group-hover:text-ink/70 transition-colors">
 											{otherPost.data.title}
 										</h3>
@@ -234,7 +234,7 @@ const breadcrumbs = [
 			<section class="px-6 md:px-12 lg:px-16 pb-16 md:pb-24">
 				<div class="max-w-2xl mx-auto">
 					<a
-						href="/blog"
+						href="/blog/"
 						class="inline-flex items-center gap-2 text-ink/40 hover:text-ink text-sm transition-colors"
 					>
 						<span>&larr;</span>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -64,14 +64,14 @@ const breadcrumbs = [
 				<div class="max-w-3xl mx-auto">
 					<div class="flex flex-wrap justify-center gap-2">
 						<a
-							href="/blog"
+							href="/blog/"
 							class="px-4 py-2 text-sm font-medium bg-ink text-canvas rounded-full hover:bg-ink/80 transition-colors"
 						>
 							Alles
 						</a>
 						{allTags.map((tag) => (
 							<a
-								href={`/blog/tag/${tag.toLowerCase().replace(/\s+/g, "-")}`}
+								href={`/blog/tag/${tag.toLowerCase().replace(/\s+/g, "-")}/`}
 								class="px-4 py-2 text-sm font-medium bg-ink/5 text-ink/70 rounded-full hover:bg-ink/10 transition-colors"
 							>
 								{tag}
@@ -86,7 +86,7 @@ const breadcrumbs = [
 		{featuredPost && (
 			<section class="px-6 md:px-12 lg:px-16 bg-canvas pb-8 md:pb-12">
 				<div class="max-w-3xl mx-auto">
-					<a href={`/blog/${featuredPost.slug}`} class="group block">
+					<a href={`/blog/${featuredPost.slug}/`} class="group block">
 						<article class="bg-ink text-canvas rounded-2xl overflow-hidden hover:shadow-2xl transition-shadow duration-300">
 							<!-- Featured image -->
 							<div class="aspect-[2/1] bg-ink overflow-hidden">

--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -55,7 +55,7 @@ const breadcrumbs = [
 		<section class="pt-32 pb-12 md:pb-16 px-6 md:px-12 lg:px-16 bg-canvas">
 			<div class="max-w-3xl mx-auto text-center">
 				<a
-					href="/blog"
+					href="/blog/"
 					class="inline-flex items-center gap-2 text-ink/40 hover:text-ink text-sm mb-6 transition-colors"
 				>
 					<span>&larr;</span>
@@ -75,14 +75,14 @@ const breadcrumbs = [
 			<div class="max-w-3xl mx-auto">
 				<div class="flex flex-wrap justify-center gap-2">
 					<a
-						href="/blog"
+						href="/blog/"
 						class="px-4 py-2 text-sm font-medium bg-ink/5 text-ink/70 rounded-full hover:bg-ink/10 transition-colors"
 					>
 						Alles
 					</a>
 					{allTags.map((t) => (
 						<a
-							href={`/blog/tag/${t.toLowerCase().replace(/\s+/g, "-")}`}
+							href={`/blog/tag/${t.toLowerCase().replace(/\s+/g, "-")}/`}
 							class:list={[
 								"px-4 py-2 text-sm font-medium rounded-full transition-colors",
 								t === tag

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -155,7 +155,7 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 								class="mt-1 w-4 h-4 shrink-0 accent-electric"
 							/>
 							<label for="privacy" class="text-sm text-ink/60">
-								Ik ga akkoord met de <a href="/privacy" class="underline hover:text-ink transition-colors">privacyverklaring</a>
+								Ik ga akkoord met de <a href="/privacy/" class="underline hover:text-ink transition-colors">privacyverklaring</a>
 							</label>
 						</div>
 
@@ -201,7 +201,7 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 									Kies een moment dat jou uitkomt. 15 minuten, vrijblijvend.
 								</p>
 								<a
-									href="/aanvragen"
+									href="/aanvragen/"
 									class="inline-flex items-center justify-center gap-3 px-6 py-3 bg-acid text-ink font-bold uppercase tracking-tight text-sm hover:bg-canvas hover:text-ink transition-colors duration-300 group w-full"
 								>
 									Plan een gesprek in

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -55,7 +55,7 @@ const projects = getAllProjects();
 
 				<!-- CTA -->
 				<a
-					href="/aanvragen"
+					href="/aanvragen/"
 					class="w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group mb-12 md:mb-16"
 				>
 				Laten we kennismaken
@@ -113,7 +113,7 @@ const projects = getAllProjects();
 								Ik geloof dat een kleine ondernemer dezelfde tools verdient als een groot bedrijf. Daarom bouw ik websites die voor je werken, ook als jij er niet bent. Geen gedoe met plugins, updates of technische problemen. Gewoon een site die doet wat hij moet doen.
 							</p>
 						</div>
-						<a href="/over-mij" class="inline-flex items-center gap-2 text-acid font-mono text-sm uppercase tracking-wider hover:text-canvas transition-colors group mt-6">
+						<a href="/over-mij/" class="inline-flex items-center gap-2 text-acid font-mono text-sm uppercase tracking-wider hover:text-canvas transition-colors group mt-6">
 							<span>Meer over mij</span>
 							<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 						</a>
@@ -134,7 +134,7 @@ const projects = getAllProjects();
 
 				<div class="grid md:grid-cols-2 gap-8 md:gap-12">
 					<!-- Website -->
-					<a href="/website-laten-maken" class="group block">
+					<a href="/website-laten-maken/" class="group block">
 						<div class="bg-ink p-8 md:p-10 group-hover:bg-ink/90 transition-colors">
 							<div class="flex items-center justify-between mb-8">
 								<span class="text-acid font-mono text-sm uppercase tracking-wider">Websites</span>
@@ -155,7 +155,7 @@ const projects = getAllProjects();
 					</a>
 
 					<!-- Automations -->
-					<a href="/automations" class="group block">
+					<a href="/automations/" class="group block">
 						<div class="bg-ink p-8 md:p-10 group-hover:bg-ink/90 transition-colors">
 							<div class="flex items-center justify-between mb-8">
 								<span class="text-acid font-mono text-sm uppercase tracking-wider">Automations</span>
@@ -214,7 +214,7 @@ const projects = getAllProjects();
 							Van sportscholen tot luxe interieurzaken. Elk project is maatwerk, gebouwd om resultaat te leveren.
 						</p>
 						<a
-							href="/portfolio"
+							href="/portfolio/"
 							class="inline-flex items-center gap-3 text-acid font-mono text-sm uppercase tracking-wider hover:text-canvas transition-colors group"
 						>
 							<span>Bekijk alle projecten</span>
@@ -282,7 +282,7 @@ const projects = getAllProjects();
 							class="mt-1 w-4 h-4 shrink-0 accent-electric"
 						/>
 						<label for="audit-privacy" class="text-sm text-ink/60">
-							Ik ga akkoord met de <a href="/privacy" class="underline hover:text-ink transition-colors">privacyverklaring</a>
+							Ik ga akkoord met de <a href="/privacy/" class="underline hover:text-ink transition-colors">privacyverklaring</a>
 						</label>
 					</div>
 

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -40,7 +40,7 @@ const breadcrumbs = [
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-12 lg:gap-16">
                     {projects.map((project) => (
                         <a
-                            href={`/project/${project.slug}`}
+                            href={`/project/${project.slug}/`}
                             class="group block"
                         >
                             <!-- Project Image -->

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -128,7 +128,7 @@ import Footer from "../components/Footer.astro";
                                 Hieronder staat precies welke gegevens per formulier worden gevraagd.
                             </p>
 
-                            <p class="mt-6"><strong class="text-ink">Aanvraagformulier</strong> (<a href="/aanvragen" class="text-ink underline decoration-acid decoration-2 underline-offset-4 hover:bg-acid hover:decoration-transparent transition-colors">/aanvragen</a>)</p>
+                            <p class="mt-6"><strong class="text-ink">Aanvraagformulier</strong> (<a href="/aanvragen/" class="text-ink underline decoration-acid decoration-2 underline-offset-4 hover:bg-acid hover:decoration-transparent transition-colors">/aanvragen</a>)</p>
                             <p><em class="text-ink/60 not-italic">Doel: om je aanvraag te verwerken en een kennismakingsgesprek in te plannen.</em></p>
                             <ul class="list-disc pl-5 space-y-1 mt-2">
                                 <li>Naam en bedrijfsnaam</li>
@@ -139,7 +139,7 @@ import Footer from "../components/Footer.astro";
                                 <li>Gewenste afspraakdatum en -tijd</li>
                             </ul>
 
-                            <p class="mt-6"><strong class="text-ink">Contactformulier</strong> (<a href="/contact" class="text-ink underline decoration-acid decoration-2 underline-offset-4 hover:bg-acid hover:decoration-transparent transition-colors">/contact</a>)</p>
+                            <p class="mt-6"><strong class="text-ink">Contactformulier</strong> (<a href="/contact/" class="text-ink underline decoration-acid decoration-2 underline-offset-4 hover:bg-acid hover:decoration-transparent transition-colors">/contact</a>)</p>
                             <p><em class="text-ink/60 not-italic">Doel: om je vraag te beantwoorden.</em></p>
                             <ul class="list-disc pl-5 space-y-1 mt-2">
                                 <li>Naam en bedrijfsnaam</li>

--- a/src/pages/project/[slug].astro
+++ b/src/pages/project/[slug].astro
@@ -38,7 +38,7 @@ const pageTitle = `Maatwerk website voor ${project.title} | ${project.industry}`
 				<div class="flex items-center gap-2 text-ink/60 font-mono text-xs uppercase tracking-wider mb-8">
 					<a href="/" class="hover:text-electric transition-colors">Home</a>
 					<span>/</span>
-					<a href="/portfolio" class="hover:text-electric transition-colors">Projecten</a>
+					<a href="/portfolio/" class="hover:text-electric transition-colors">Projecten</a>
 					<span>/</span>
 					<span class="text-ink">{project.title}</span>
 				</div>
@@ -92,7 +92,7 @@ const pageTitle = `Maatwerk website voor ${project.title} | ${project.industry}`
 						<span class="transition-transform duration-300 group-hover:translate-x-1">&rarr;</span>
 					</a>
 					<a
-						href="/aanvragen"
+						href="/aanvragen/"
 						class="w-full sm:w-auto border-2 border-ink text-ink px-8 py-[18px] font-bold uppercase tracking-tight hover:bg-ink hover:text-canvas transition-colors duration-300 text-center"
 					>
 						Start Jouw Project
@@ -249,7 +249,7 @@ const pageTitle = `Maatwerk website voor ${project.title} | ${project.industry}`
 						</h2>
 					</div>
 					<a
-						href="/portfolio"
+						href="/portfolio/"
 						class="hidden md:inline-flex items-center gap-2 text-ink font-mono text-sm uppercase tracking-wider hover:text-electric transition-colors group"
 					>
 						<span>Alle projecten</span>
@@ -263,7 +263,7 @@ const pageTitle = `Maatwerk website voor ${project.title} | ${project.industry}`
 						.slice(0, 2)
 						.map((relatedProject) => (
 							<a
-								href={`/project/${relatedProject.slug}`}
+								href={`/project/${relatedProject.slug}/`}
 								class="group block"
 							>
 								<!-- Project Image -->
@@ -296,7 +296,7 @@ const pageTitle = `Maatwerk website voor ${project.title} | ${project.industry}`
 
 				<!-- Mobile link -->
 				<a
-					href="/portfolio"
+					href="/portfolio/"
 					class="md:hidden mt-8 inline-flex items-center gap-2 text-ink font-mono text-sm uppercase tracking-wider hover:text-electric transition-colors group"
 				>
 					<span>Alle projecten</span>

--- a/src/pages/sitemap.astro
+++ b/src/pages/sitemap.astro
@@ -41,12 +41,12 @@ const blogPosts = getAllBlogPosts();
                             </a>
                         </li>
                         <li>
-                            <a href="/portfolio" class="text-ink/70 hover:text-electric transition-colors font-medium">
+                            <a href="/portfolio/" class="text-ink/70 hover:text-electric transition-colors font-medium">
                                 Portfolio
                             </a>
                         </li>
                         <li>
-                            <a href="/blog" class="text-ink/70 hover:text-electric transition-colors font-medium">
+                            <a href="/blog/" class="text-ink/70 hover:text-electric transition-colors font-medium">
                                 Blog
                             </a>
                         </li>
@@ -61,7 +61,7 @@ const blogPosts = getAllBlogPosts();
                             </a>
                         </li>
                         <li>
-                            <a href="/aanvragen" class="text-ink/70 hover:text-electric transition-colors font-medium">
+                            <a href="/aanvragen/" class="text-ink/70 hover:text-electric transition-colors font-medium">
                                 Aanvragen
                             </a>
                         </li>
@@ -77,7 +77,7 @@ const blogPosts = getAllBlogPosts();
                     <ul class="space-y-3">
                         {projects.map((project) => (
                             <li>
-                                <a href={`/project/${project.slug}`} class="text-ink/70 hover:text-electric transition-colors font-medium">
+                                <a href={`/project/${project.slug}/`} class="text-ink/70 hover:text-electric transition-colors font-medium">
                                     {project.title}
                                 </a>
                             </li>
@@ -94,7 +94,7 @@ const blogPosts = getAllBlogPosts();
                     <ul class="space-y-3">
                         {blogPosts.map((post) => (
                             <li>
-                                <a href={`/blog/${post.slug}`} class="text-ink/70 hover:text-electric transition-colors font-medium">
+                                <a href={`/blog/${post.slug}/`} class="text-ink/70 hover:text-electric transition-colors font-medium">
                                     {post.title}
                                 </a>
                             </li>
@@ -111,7 +111,7 @@ const blogPosts = getAllBlogPosts();
                     <ul class="space-y-3">
                         {cities.map((city) => (
                             <li>
-                                <a href={`/webdesign-${city.slug}`} class="text-ink/70 hover:text-electric transition-colors font-medium">
+                                <a href={`/webdesign-${city.slug}/`} class="text-ink/70 hover:text-electric transition-colors font-medium">
                                     Webdesign {city.name}
                                 </a>
                             </li>
@@ -127,17 +127,17 @@ const blogPosts = getAllBlogPosts();
                     </h2>
                     <ul class="space-y-3">
                         <li>
-                            <a href="/algemene-voorwaarden" class="text-ink/70 hover:text-electric transition-colors font-medium">
+                            <a href="/algemene-voorwaarden/" class="text-ink/70 hover:text-electric transition-colors font-medium">
                                 Algemene Voorwaarden
                             </a>
                         </li>
                         <li>
-                            <a href="/privacy" class="text-ink/70 hover:text-electric transition-colors font-medium">
+                            <a href="/privacy/" class="text-ink/70 hover:text-electric transition-colors font-medium">
                                 Privacyverklaring
                             </a>
                         </li>
                         <li>
-                            <a href="/sitemap" class="text-ink/70 hover:text-electric transition-colors font-medium">
+                            <a href="/sitemap/" class="text-ink/70 hover:text-electric transition-colors font-medium">
                                 Sitemap
                             </a>
                         </li>

--- a/src/pages/webdesign-[city].astro
+++ b/src/pages/webdesign-[city].astro
@@ -84,7 +84,7 @@ const breadcrumbs = [
                         </div>
 
                         <a
-                            href="/aanvragen"
+                            href="/aanvragen/"
                             class="w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group"
                         >
                             Gratis Kennismakingsgesprek

--- a/src/pages/website-laten-maken.astro
+++ b/src/pages/website-laten-maken.astro
@@ -78,7 +78,7 @@ const faqs = [
 				</p>
 
 				<a
-					href="/aanvragen"
+					href="/aanvragen/"
 					class="w-full sm:w-auto bg-acid text-ink px-8 py-5 font-bold uppercase tracking-tight hover:bg-ink hover:text-acid transition-colors duration-300 inline-flex items-center justify-center gap-3 group mb-12 md:mb-16"
 				>
 					Laten we kennismaken
@@ -239,7 +239,7 @@ const faqs = [
 							<p class="text-ink/50 text-sm mb-6">excl. BTW · klaar in 7 dagen</p>
 
 							<a
-								href="/aanvragen"
+								href="/aanvragen/"
 								class="w-full bg-ink text-canvas py-4 font-bold uppercase tracking-tight text-sm hover:bg-acid hover:text-ink transition-colors duration-300 text-center inline-flex items-center justify-center gap-3 group"
 							>
 								Kies Website
@@ -301,7 +301,7 @@ const faqs = [
 							<p class="text-ink/60 text-sm mb-6">excl. BTW · klaar in 2-3 weken</p>
 
 							<a
-								href="/aanvragen"
+								href="/aanvragen/"
 								class="w-full bg-ink text-acid py-4 font-bold uppercase tracking-tight text-sm hover:bg-acid hover:text-ink transition-colors duration-300 text-center inline-flex items-center justify-center gap-3 group"
 							>
 								Kies Systeem


### PR DESCRIPTION
## Summary
- Adds trailing slashes to all internal `href` links across the codebase
- Ensures consistency between sitemap URLs and actual link hrefs
- Eliminates unnecessary 308 redirects on every internal navigation

## Why this matters
The sitemap and Astro config use `trailingSlash: "always"`, but internal links were missing trailing slashes. This caused:
- Extra HTTP redirect on every click (slower navigation)
- Inconsistent URL signals to Google
- Potential SEO confusion during crawling

## Files changed (22 files)
- **Navigation**: Header.astro, Footer.astro
- **Pages**: 404, index, contact, aanvragen, privacy, algemene-voorwaarden, sitemap, website-laten-maken, automations, portfolio
- **Blog**: index, [slug], tag/[tag]
- **Dynamic pages**: project/[slug], webdesign-[city]
- **Components**: OfferSection, OfferLocalSEOSection, LocalSEOSection, PortfolioSection, BlogCard

## Test plan
- [x] Build passes (`npm run build`)
- [ ] Verify internal links navigate without 308 redirect
- [ ] Check sitemap URLs match link hrefs

🤖 Generated with [Claude Code](https://claude.com/claude-code)