### PR TITLE
fix(seo): add trailing slashes to schema/breadcrumb URLs and blog links to footer 🐛

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,7 @@
 ---
 import TextRevealCSS from "./TextRevealCSS.astro";
 import { getAllCities } from "../data/cities";
+import { getAllBlogPosts } from "../data/blog";
 
 interface Props {
 	hideCTA?: boolean;
@@ -15,6 +16,7 @@ const {
 } = Astro.props;
 
 const cities = getAllCities();
+const blogPosts = getAllBlogPosts();
 
 // Group cities by region for organized display
 const cityGroups = cities.reduce((groups, city) => {
@@ -86,6 +88,28 @@ const regionOrder = ["Rivierenland", "Regio Utrecht", "Noord-Brabant", "Gelderla
 							</div>
 						</div>
 					)
+				))}
+			</div>
+		</div>
+
+		<!-- Blog Articles -->
+		<div class="mb-12 md:mb-16 text-center">
+			<div class="font-mono text-xs uppercase tracking-widest text-canvas/40 mb-6">
+				Artikelen
+			</div>
+			<div class="flex flex-wrap justify-center items-center gap-y-2 font-mono text-xs text-canvas/50 uppercase tracking-widest">
+				{blogPosts.map((post, i) => (
+					<>
+						<a
+							href={`/blog/${post.slug}/`}
+							class="hover:text-acid transition-colors"
+						>
+							{post.shortTitle}
+						</a>
+						{i < blogPosts.length - 1 && (
+							<span class="mx-3 text-canvas/20">&middot;</span>
+						)}
+					</>
 				))}
 			</div>
 		</div>

--- a/src/components/seo/BlogPostSchema.astro
+++ b/src/components/seo/BlogPostSchema.astro
@@ -29,7 +29,7 @@ const {
 	image,
 } = Astro.props;
 
-const url = `https://knapgemaakt.nl/blog/${slug}`;
+const url = `https://knapgemaakt.nl/blog/${slug}/`;
 const logoUrl = "https://knapgemaakt.nl/favicon_final.svg";
 const imageUrl = image ? `https://knapgemaakt.nl${image}` : logoUrl;
 
@@ -72,7 +72,7 @@ const schema = {
 	inLanguage: "nl-NL",
 	isPartOf: {
 		"@type": "Blog",
-		"@id": "https://knapgemaakt.nl/blog",
+		"@id": "https://knapgemaakt.nl/blog/",
 		name: "KNAP GEMAAKT. Blog",
 		description: "Tips, gidsen en inzichten over webdesign voor ondernemers",
 	},

--- a/src/data/blog.ts
+++ b/src/data/blog.ts
@@ -8,6 +8,7 @@
 export interface BlogPostMeta {
 	slug: string;
 	title: string;
+	shortTitle: string; // Compact label for footer links
 	publishDate: string; // ISO date string
 }
 
@@ -19,36 +20,43 @@ export const blogPosts: BlogPostMeta[] = [
 	{
 		slug: "ideal-wordt-wero",
 		title: "iDEAL wordt Wero: Wat betekent dit voor jouw webshop?",
+		shortTitle: "iDEAL wordt Wero",
 		publishDate: "2026-01-29",
 	},
 	{
 		slug: "wero-webshops-checklist-maart",
 		title: "Wero voor webshops: 5 dingen die je voor 31 maart moet regelen",
+		shortTitle: "Wero checklist webshops",
 		publishDate: "2026-01-30",
 	},
 	{
 		slug: "wero-kosten-transactiekosten",
 		title: "Wat kost Wero? Transactiekosten voor ondernemers uitgelegd",
+		shortTitle: "Wero transactiekosten",
 		publishDate: "2026-01-31",
 	},
 	{
 		slug: "wero-mollie-integratie",
 		title: "Wero en Mollie: Hoe werkt de integratie?",
+		shortTitle: "Wero & Mollie",
 		publishDate: "2026-02-01",
 	},
 	{
 		slug: "website-laten-maken-kosten",
 		title: "Wat kost een website laten maken in 2026? Complete prijsgids",
+		shortTitle: "Website kosten 2026",
 		publishDate: "2026-01-31",
 	},
 	{
 		slug: "meer-verkopen-duitsers-wero",
 		title: "Meer verkopen aan Duitsers met Wero",
+		shortTitle: "Verkopen aan Duitsers",
 		publishDate: "2026-02-02",
 	},
 	{
 		slug: "website-500-of-5000-verschil",
 		title: "Website laten maken: €500 of €5000? Het verschil uitgelegd",
+		shortTitle: "€500 vs €5000",
 		publishDate: "2026-02-03",
 	},
 ];

--- a/src/pages/automations.astro
+++ b/src/pages/automations.astro
@@ -10,7 +10,7 @@ import BreadcrumbSchema from "../components/seo/BreadcrumbSchema.astro";
 
 const breadcrumbs = [
 	{ name: "Home", url: "https://knapgemaakt.nl/" },
-	{ name: "Automations", url: "https://knapgemaakt.nl/automations" },
+	{ name: "Automations", url: "https://knapgemaakt.nl/automations/" },
 ];
 
 const faqs = [

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -52,8 +52,8 @@ const metaDescription = post.data.description;
 
 const breadcrumbs = [
 	{ name: "Home", url: "https://knapgemaakt.nl/" },
-	{ name: "Blog", url: "https://knapgemaakt.nl/blog" },
-	{ name: post.data.title, url: `https://knapgemaakt.nl/blog/${post.slug}` },
+	{ name: "Blog", url: "https://knapgemaakt.nl/blog/" },
+	{ name: post.data.title, url: `https://knapgemaakt.nl/blog/${post.slug}/` },
 ];
 ---
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -38,7 +38,7 @@ const metaDescription =
 
 const breadcrumbs = [
 	{ name: "Home", url: "https://knapgemaakt.nl/" },
-	{ name: "Blog", url: "https://knapgemaakt.nl/blog" },
+	{ name: "Blog", url: "https://knapgemaakt.nl/blog/" },
 ];
 ---
 

--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -42,8 +42,8 @@ const metaDescription = `Artikelen over ${tag.toLowerCase()}. Tips en inzichten 
 
 const breadcrumbs = [
 	{ name: "Home", url: "https://knapgemaakt.nl/" },
-	{ name: "Blog", url: "https://knapgemaakt.nl/blog" },
-	{ name: tag, url: `https://knapgemaakt.nl/blog/tag/${tagSlug}` },
+	{ name: "Blog", url: "https://knapgemaakt.nl/blog/" },
+	{ name: tag, url: `https://knapgemaakt.nl/blog/tag/${tagSlug}/` },
 ];
 ---
 

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -12,7 +12,7 @@ const metaDescription = "Bekijk onze website voorbeelden voor lokale ondernemers
 
 const breadcrumbs = [
 	{ name: "Home", url: "https://knapgemaakt.nl/" },
-	{ name: "Portfolio", url: "https://knapgemaakt.nl/portfolio" },
+	{ name: "Portfolio", url: "https://knapgemaakt.nl/portfolio/" },
 ];
 ---
 

--- a/src/pages/project/[slug].astro
+++ b/src/pages/project/[slug].astro
@@ -20,8 +20,8 @@ const metaDescription = `Maatwerk website voor ${project.title} - ${project.shor
 
 const breadcrumbs = [
 	{ name: "Home", url: "https://knapgemaakt.nl/" },
-	{ name: "Projecten", url: "https://knapgemaakt.nl/portfolio" },
-	{ name: `Maatwerk website voor ${project.title}`, url: `https://knapgemaakt.nl/project/${project.slug}` },
+	{ name: "Projecten", url: "https://knapgemaakt.nl/portfolio/" },
+	{ name: `Maatwerk website voor ${project.title}`, url: `https://knapgemaakt.nl/project/${project.slug}/` },
 ];
 
 // SEO title with "maatwerk website" format

--- a/src/pages/webdesign-[city].astro
+++ b/src/pages/webdesign-[city].astro
@@ -47,7 +47,7 @@ const pageTitle = `Website Laten Maken ${city} | €495 | KNAP GEMAAKT.`;
 // Breadcrumb data for this page
 const breadcrumbs = [
 	{ name: "Home", url: "https://knapgemaakt.nl/" },
-	{ name: `Website Laten Maken ${city}`, url: `https://knapgemaakt.nl/webdesign-${cityData.slug}` }
+	{ name: `Website Laten Maken ${city}`, url: `https://knapgemaakt.nl/webdesign-${cityData.slug}/` }
 ];
 ---
 

--- a/src/pages/website-laten-maken.astro
+++ b/src/pages/website-laten-maken.astro
@@ -10,7 +10,7 @@ import BreadcrumbSchema from "../components/seo/BreadcrumbSchema.astro";
 
 const breadcrumbs = [
 	{ name: "Home", url: "https://knapgemaakt.nl/" },
-	{ name: "Website Laten Maken", url: "https://knapgemaakt.nl/website-laten-maken" },
+	{ name: "Website Laten Maken", url: "https://knapgemaakt.nl/website-laten-maken/" },
 ];
 
 const faqs = [


### PR DESCRIPTION
## Summary
- Fix trailing slash mismatch in BlogPostSchema structured data (`@id` and `isPartOf` URLs)
- Fix trailing slash mismatch in breadcrumb schema URLs across all 8 page templates
- Add compact blog article links with dot separators to footer for improved internal linking

## Context
Google Search Console shows "Referring page: None detected" for blog posts and redirect errors from mismatched schema/canonical URLs. These changes:
1. Align all structured data URLs with the `trailingSlash: "always"` config
2. Create footer links from every page to all blog posts, reducing link depth from 3 clicks to 1

Closes #200

## Test plan
- [ ] Verify build passes
- [ ] Check JSON-LD schema on blog posts has trailing slashes
- [ ] Check breadcrumb schema on all page types has trailing slashes
- [ ] Verify footer shows blog article links with dot separators

🤖 Generated with [Claude Code](https://claude.com/claude-code)