### PR TITLE
fix(security): ensure email obfuscation on all pages 🐛

### DIFF
--- a/src/pages/automations.astro
+++ b/src/pages/automations.astro
@@ -469,7 +469,7 @@ const steps = [
 					<!-- Error message -->
 					<div id="auto-error" class="hidden p-6 border-2 border-red-500 bg-red-500/10">
 						<p class="font-bold text-red-500 uppercase tracking-tight">Er ging iets mis</p>
-						<p class="text-ink/70 mt-2">Probeer het opnieuw of stuur een mail naar info@knapgemaakt.nl.</p>
+						<p class="text-ink/70 mt-2">Probeer het opnieuw of stuur een mail naar <a href="mailto:info@knapgemaakt.nl" class="underline hover:text-red-900 transition-colors">info@knapgemaakt.nl</a>.</p>
 					</div>
 				</form>
 			</div>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -182,7 +182,7 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 						</div>
 						<div id="form-error" class="hidden p-4 bg-red-50 border-2 border-red-300 text-red-800">
 							<p class="font-bold">Er ging iets mis</p>
-							<p class="text-sm" id="error-text">Probeer het opnieuw of stuur een e-mail naar info@knapgemaakt.nl</p>
+							<p class="text-sm" id="error-text">Probeer het opnieuw of stuur een e-mail naar <a href="mailto:info@knapgemaakt.nl" class="underline hover:text-red-900 transition-colors">info@knapgemaakt.nl</a></p>
 						</div>
 					</form>
 				</div>
@@ -356,11 +356,11 @@ import TextRevealCSS from "../components/TextRevealCSS.astro";
 					form.reset();
 				} else {
 					const err = await res.json();
-					if (errorText) errorText.textContent = err.error || 'Probeer het opnieuw of stuur een e-mail naar info@knapgemaakt.nl';
+					if (errorText) errorText.innerHTML = err.error || 'Probeer het opnieuw of stuur een e-mail naar <a href="mailto:info@knapgemaakt.nl" class="underline hover:text-red-900 transition-colors">info@knapgemaakt.nl</a>';
 					errorMsg?.classList.remove('hidden');
 				}
 			} catch {
-				if (errorText) errorText.textContent = 'Geen verbinding. Probeer het opnieuw of stuur een e-mail naar info@knapgemaakt.nl';
+				if (errorText) errorText.innerHTML = 'Geen verbinding. Probeer het opnieuw of stuur een e-mail naar <a href="mailto:info@knapgemaakt.nl" class="underline hover:text-red-900 transition-colors">info@knapgemaakt.nl</a>';
 				errorMsg?.classList.remove('hidden');
 			} finally {
 				btn.disabled = false;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -292,6 +292,10 @@ const projects = getAllProjects();
 					>
 						Check mijn website
 					</button>
+					<div id="audit-error" class="hidden mt-4 p-4 bg-red-50 border-2 border-red-300 text-red-800">
+						<p class="font-bold text-sm">Er ging iets mis</p>
+						<p class="text-sm">Probeer het opnieuw of stuur een mail naar <a href="mailto:info@knapgemaakt.nl" class="underline hover:text-red-900 transition-colors">info@knapgemaakt.nl</a>.</p>
+					</div>
 				</form>
 			</div>
 		</section>
@@ -419,7 +423,8 @@ const projects = getAllProjects();
 			} catch (error) {
 				submitBtn.disabled = false;
 				submitBtn.textContent = originalText;
-				alert('Er ging iets mis. Probeer het opnieuw of stuur een mail naar info@knapgemaakt.nl');
+				const auditError = document.getElementById('audit-error');
+				if (auditError) auditError.classList.remove('hidden');
 			}
 		});
 


### PR DESCRIPTION
## Summary
- Wrap plain-text email addresses in `mailto:` links across contact, automations, and index pages so Cloudflare's email obfuscation can protect them from scrapers
- Replace `alert()` on index page with inline error div for consistent UX and obfuscation support
- Switch `textContent` to `innerHTML` in contact page JS error handlers to render `mailto:` links

Closes #203

## Test plan
- [ ] Verify email addresses are obfuscated in page source after Cloudflare deployment
- [ ] Trigger form errors on contact, automations, and index pages to confirm error messages display correctly with clickable email links
- [ ] Confirm build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)