### PR TITLE
fix: remove overly broad /api/ 410 pattern that blocks current API endpoints

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -105,9 +105,6 @@ const LEGACY_PATTERNS = [
   /^\/assets\/projects\//,
   /^\/cities\//,
   /^\/favicon\.ico$/,
-
-  // Old API endpoints
-  /^\/api\//,
 ];
 
 export const onRequest = defineMiddleware(async (context, next) => {


### PR DESCRIPTION
## Summary
Removed the overly broad `/api/` pattern from middleware that was blocking all API endpoints including current ones like `/api/sync-blocked-times`.

The pattern was meant to catch old API endpoints from the previous website (Dutch crafts marketplace), but it was catching all API routes and returning 410 Gone errors.

## Test plan
- [ ] Verify `/api/sync-blocked-times` POST requests are processed correctly
- [ ] Confirm other API endpoints work as expected
- [ ] Check that legacy patterns still return 410 for old website content

Closes #207