### PR TITLE
fix: add Cloudflare _redirects for prerendered page redirects

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,23 @@
+# Cloudflare Pages Redirects
+# https://developers.cloudflare.com/pages/configuration/redirects/
+#
+# These redirects run at the Cloudflare edge BEFORE static file serving,
+# which is necessary because prerendered pages bypass the Astro middleware.
+# The _routes.json excludes /project/* and /blog/* from the Worker,
+# so middleware redirects never fire for these paths.
+
+# Project slug redirects (old -> new)
+/project/fitcity-culemborg /project/maatwerk-website-voor-fitcity-culemborg/ 301
+/project/fitcity-culemborg/ /project/maatwerk-website-voor-fitcity-culemborg/ 301
+/project/byshakir /project/maatwerk-website-voor-by-shakir/ 301
+/project/byshakir/ /project/maatwerk-website-voor-by-shakir/ 301
+
+# Blog post redirects (consolidated content)
+/blog/webdesign-utrecht /blog/website-laten-maken-kosten/ 301
+/blog/webdesign-utrecht/ /blog/website-laten-maken-kosten/ 301
+/blog/webshop-laten-maken /blog/website-laten-maken-kosten/ 301
+/blog/webshop-laten-maken/ /blog/website-laten-maken-kosten/ 301
+/blog/maatwerkwebsite-laten-maken /blog/website-laten-maken-kosten/ 301
+/blog/maatwerkwebsite-laten-maken/ /blog/website-laten-maken-kosten/ 301
+/blog/zelf-website-maken-of-laten-maken /blog/website-laten-maken-kosten/ 301
+/blog/zelf-website-maken-of-laten-maken/ /blog/website-laten-maken-kosten/ 301


### PR DESCRIPTION
## Summary
- Adds `public/_redirects` file to handle 301 redirects at the Cloudflare Pages edge
- Fixes old project URLs (`/project/fitcity-culemborg/`, `/project/byshakir/`) returning 404 instead of redirecting
- Also fixes blog consolidation redirects (`/blog/webdesign-utrecht/`, etc.) that were silently broken

## Root Cause
Astro's Cloudflare adapter generates `_routes.json` which excludes `/project/*` and `/blog/*` from the Worker. This means `middleware.ts` redirects never fire for prerendered pages. Cloudflare Pages `_redirects` runs at the edge before static file lookup, solving this.

## Test plan
- [ ] Verify `/project/fitcity-culemborg/` returns 301 → `/project/maatwerk-website-voor-fitcity-culemborg/`
- [ ] Verify `/project/byshakir/` returns 301 → `/project/maatwerk-website-voor-by-shakir/`
- [ ] Verify `/blog/webdesign-utrecht/` returns 301 → `/blog/website-laten-maken-kosten/`
- [ ] Verify existing pages still load normally

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)