### PR TITLE
fix: remove /website-laten-maken/ from legacy URL patterns

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -91,7 +91,6 @@ const LEGACY_PATTERNS = [
   /^\/geopend-kerstshop/,
   /^\/onze-najaar-shop/,
   /^\/familiefeest\/?$/,
-  /^\/website-laten-maken\/?$/,
   /^\/agenda-kunstmarkten-2020\/?$/,
 
   // Apple app association files (not applicable)


### PR DESCRIPTION
Closes #211

The /website-laten-maken/ page exists as an active service page in src/pages/website-laten-maken.astro but was being blocked by a legacy pattern in middleware that returns 410 Gone. This pattern was likely added when this URL belonged to the old WordPress marketplace, but it's now a core page in the current website.

Removing this pattern from LEGACY_PATTERNS allows the actual page to be served.