### PR TITLE
fix: add 410 Gone responses for removed pages

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -21,3 +21,21 @@
 /blog/maatwerkwebsite-laten-maken/ /blog/website-laten-maken-kosten/ 301
 /blog/zelf-website-maken-of-laten-maken /blog/website-laten-maken-kosten/ 301
 /blog/zelf-website-maken-of-laten-maken/ /blog/website-laten-maken-kosten/ 301
+
+# Removed blog tag pages (410 Gone)
+/blog/tag/tips 410
+/blog/tag/tips/ 410
+/blog/tag/utrecht 410
+/blog/tag/utrecht/ 410
+/blog/tag/wordpress 410
+/blog/tag/wordpress/ 410
+/blog/tag/gids 410
+/blog/tag/gids/ 410
+/blog/tag/maatwerk 410
+/blog/tag/maatwerk/ 410
+/blog/tag/vergelijking 410
+/blog/tag/vergelijking/ 410
+
+# Removed projects (410 Gone)
+/project/schildersbedrijf-visser 410
+/project/schildersbedrijf-visser/ 410


### PR DESCRIPTION
Add Cloudflare _redirects rules to return 410 Gone for removed blog tag pages and projects that bypass SSR middleware.