### PR TITLE
feat: add Wero blog posts 1.6 and 1.7

### DIFF
--- a/src/data/blog.ts
+++ b/src/data/blog.ts
@@ -59,6 +59,18 @@ export const blogPosts: BlogPostMeta[] = [
 		shortTitle: "€500 vs €5000",
 		publishDate: "2026-02-03",
 	},
+	{
+		slug: "wero-vs-ideal-verschillen",
+		title: "Wero vs iDEAL: De 7 belangrijkste verschillen",
+		shortTitle: "Wero vs iDEAL",
+		publishDate: "2026-02-12",
+	},
+	{
+		slug: "wero-request-to-pay-zzp",
+		title: "Request-to-Pay met Wero: Sneller betaald worden als ZZP'er",
+		shortTitle: "Wero Request-to-Pay",
+		publishDate: "2026-02-13",
+	},
 ];
 
 export function getAllBlogPosts(): BlogPostMeta[] {


### PR DESCRIPTION
## Summary
- Register wero-vs-ideal-verschillen (1.6) and wero-request-to-pay-zzp (1.7) in blog.ts for sitemap and footer links
- Blog content and images were added in previous commit, this registers them in the data layer

## Test plan
- [ ] Verify /blog/wero-vs-ideal-verschillen/ loads correctly
- [ ] Verify /blog/wero-request-to-pay-zzp/ loads correctly
- [ ] Check sitemap includes both new posts
- [ ] Verify footer shows new blog links

🤖 Generated with [Claude Code](https://claude.com/claude-code)