### PR TITLE
fix: add 301 redirects for removed blog posts and projects

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -22,20 +22,12 @@
 /blog/zelf-website-maken-of-laten-maken /blog/website-laten-maken-kosten/ 301
 /blog/zelf-website-maken-of-laten-maken/ /blog/website-laten-maken-kosten/ 301
 
-# Removed blog tag pages (410 Gone)
-/blog/tag/tips 410
-/blog/tag/tips/ 410
-/blog/tag/utrecht 410
-/blog/tag/utrecht/ 410
-/blog/tag/wordpress 410
-/blog/tag/wordpress/ 410
-/blog/tag/gids 410
-/blog/tag/gids/ 410
-/blog/tag/maatwerk 410
-/blog/tag/maatwerk/ 410
-/blog/tag/vergelijking 410
-/blog/tag/vergelijking/ 410
+# Removed blog posts (redirect to closest existing content)
+/blog/website-voor-zzp /blog/website-laten-maken-kosten/ 301
+/blog/website-voor-zzp/ /blog/website-laten-maken-kosten/ 301
+/blog/wordpress-vs-moderne-alternatieven /blog/website-500-of-5000-verschil/ 301
+/blog/wordpress-vs-moderne-alternatieven/ /blog/website-500-of-5000-verschil/ 301
 
-# Removed projects (410 Gone)
-/project/schildersbedrijf-visser 410
-/project/schildersbedrijf-visser/ 410
+# Removed projects (redirect to portfolio)
+/project/schildersbedrijf-visser /portfolio/ 301
+/project/schildersbedrijf-visser/ /portfolio/ 301

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -71,7 +71,6 @@ const LEGACY_PATTERNS = [
   /^\/kralen-en-vilt\/?$/,
   /^\/vazen\/?$/,
   /^\/verslingerd\/?$/,
-  /^\/webdesign-utrecht\/?$/,
 
   // Old tag pages
   /^\/tag\//,


### PR DESCRIPTION
Closes #216

## Changes

- `/blog/website-voor-zzp/` → 301 to `/blog/website-laten-maken-kosten/`
- `/blog/wordpress-vs-moderne-alternatieven/` → 301 to `/blog/website-500-of-5000-verschil/`
- `/project/schildersbedrijf-visser/` → 301 to `/portfolio/`
- Removed `/webdesign-utrecht/` from middleware LEGACY_PATTERNS (live page, not legacy)
- Removed non-functional 410 entries (Cloudflare Pages doesn't support 410 in _redirects)