### PR TITLE
fix: correct API route import paths after directory restructure

### DIFF
--- a/src/pages/api/availability-month/index.ts
+++ b/src/pages/api/availability-month/index.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import availabilityConfig from '../../config/availability.json';
+import availabilityConfig from '../../../config/availability.json';
 
 interface Env {
   knapgemaakt_bookings: D1Database;

--- a/src/pages/api/availability/index.ts
+++ b/src/pages/api/availability/index.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import availabilityConfig from '../../config/availability.json';
+import availabilityConfig from '../../../config/availability.json';
 
 interface Env {
   knapgemaakt_bookings: D1Database;

--- a/src/pages/api/bookings/index.ts
+++ b/src/pages/api/bookings/index.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { createBooking } from '../../lib/create-booking';
+import { createBooking } from '../../../lib/create-booking';
 
 interface Env {
   knapgemaakt_bookings: D1Database;

--- a/src/pages/api/submissions/index.ts
+++ b/src/pages/api/submissions/index.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { createBooking } from '../../lib/create-booking';
+import { createBooking } from '../../../lib/create-booking';
 
 interface Env {
   knapgemaakt_bookings: D1Database;


### PR DESCRIPTION
## Summary
- Fixed broken relative imports in 4 API routes after they were moved to `index.ts` subdirectories for `trailingSlash: always` support
- `../../config/` → `../../../config/` (availability routes)
- `../../lib/` → `../../../lib/` (bookings/submissions routes)

## Root cause
Commit 1d56bbd restructured API routes from `api/name.ts` to `api/name/index.ts` but didn't update the relative import paths, adding one extra directory level.

## Test plan
- [ ] Cloudflare build succeeds
- [ ] API endpoints respond correctly
- [ ] Blog posts 1.6 and 1.7 are live

🤖 Generated with [Claude Code](https://claude.com/claude-code)