### PR TITLE
fix: show Utrecht in footer by aligning region name

### DIFF
--- a/src/data/cities.ts
+++ b/src/data/cities.ts
@@ -498,7 +498,7 @@ export const cities: Record<string, CityData> = {
 	utrecht: {
 		name: "Utrecht",
 		slug: "utrecht",
-		region: "Utrecht",
+		region: "Regio Utrecht",
 		population: "360.000 inwoners",
 		nearbyAreas: ["De Bilt", "Zeist", "Bunnik", "Maarssen"],
 		landmarks: "Domtoren, Oudegracht, Neude",


### PR DESCRIPTION
## Problem

Utrecht city page (`/webdesign-utrecht/`) was missing from the footer's "Webdesign in jouw regio" section.

## Root Cause

The Utrecht entry in `cities.ts` had `region: "Utrecht"` while the footer iterates over `regionOrder` which contains `"Regio Utrecht"`. All other cities in the area (Houten, Nieuwegein, etc.) correctly use `region: "Regio Utrecht"`.

## Fix

Changed Utrecht's region from `"Utrecht"` to `"Regio Utrecht"` to match the footer's `regionOrder`.

Note: The XML sitemap was unaffected — it uses `getAllCities()` which returns all cities regardless of region.