### PR TITLE
feat: enhance blog overview with image grid layout

### DIFF
--- a/src/components/blog/BlogCardImage.astro
+++ b/src/components/blog/BlogCardImage.astro
@@ -1,0 +1,76 @@
+---
+/**
+ * BlogCardImage Component
+ * Blog card with thumbnail image for the grid section.
+ * Used between the featured hero and the compact text list.
+ */
+
+interface Props {
+	title: string;
+	description: string;
+	publishDate: Date;
+	slug: string;
+	image: string;
+	imageAlt?: string;
+	tags?: string[];
+	readingTime?: number;
+}
+
+const { title, description, publishDate, slug, image, imageAlt, tags = [], readingTime } = Astro.props;
+
+const formattedDate = publishDate.toLocaleDateString("nl-NL", {
+	year: "numeric",
+	month: "short",
+	day: "numeric",
+});
+
+const estimatedReadingTime = readingTime || 5;
+---
+
+<article class="group">
+	<a href={`/blog/${slug}/`} class="block rounded-2xl overflow-hidden border border-ink/8 hover:border-ink/15 hover:shadow-lg transition-all duration-300">
+		<!-- Thumbnail -->
+		<div class="aspect-[3/2] overflow-hidden bg-ink/5">
+			<img
+				src={image}
+				alt={imageAlt || title}
+				class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+				loading="lazy"
+				decoding="async"
+			/>
+		</div>
+
+		<!-- Content -->
+		<div class="p-5">
+			<!-- Tags -->
+			{tags.length > 0 && (
+				<div class="flex flex-wrap gap-1.5 mb-3">
+					{tags.slice(0, 2).map((tag) => (
+						<span class="px-2.5 py-0.5 bg-ink/5 text-ink/60 text-xs font-medium rounded-full">
+							{tag}
+						</span>
+					))}
+				</div>
+			)}
+
+			<!-- Title -->
+			<h2 class="text-lg font-bold text-ink leading-snug mb-2 group-hover:text-ink/70 transition-colors line-clamp-2">
+				{title}
+			</h2>
+
+			<!-- Description -->
+			<p class="text-ink/55 text-sm leading-relaxed mb-3 line-clamp-2">
+				{description}
+			</p>
+
+			<!-- Meta -->
+			<div class="flex items-center gap-2 text-xs text-ink/40">
+				<time datetime={publishDate.toISOString()}>
+					{formattedDate}
+				</time>
+				<span>&middot;</span>
+				<span>{estimatedReadingTime} min</span>
+			</div>
+		</div>
+	</a>
+</article>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -3,6 +3,7 @@ import Layout from "../../layouts/Layout.astro";
 import Footer from "../../components/Footer.astro";
 import BlogPostSchema from "../../components/seo/BlogPostSchema.astro";
 import BreadcrumbSchema from "../../components/seo/BreadcrumbSchema.astro";
+import BlogCardImage from "../../components/blog/BlogCardImage.astro";
 import { getCollection, type CollectionEntry } from "astro:content";
 
 export const prerender = true;
@@ -22,7 +23,7 @@ interface Props {
 const { post } = Astro.props;
 const { Content } = await post.render();
 
-// Get other posts for "More articles" section (exclude current post, max 3)
+// Get other posts for "Verder lezen?" section (exclude current post, max 3)
 const allPosts = await getCollection("blog", ({ data }) => !data.draft);
 const otherPosts = allPosts
 	.filter((p) => p.slug !== post.slug)
@@ -194,37 +195,24 @@ const breadcrumbs = [
 				</div>
 			</section>
 
-			<!-- More Articles -->
+			<!-- Verder lezen? -->
 			{otherPosts.length > 0 && (
 				<section class="px-6 md:px-12 lg:px-16 py-12 md:py-16">
-					<div class="max-w-2xl mx-auto">
-						<h2 class="text-2xl font-bold mb-8">Meer artikelen</h2>
-						<div class="space-y-6">
-							{otherPosts.map((otherPost) => {
-								const otherReadingTime = otherPost.data.readingTime || Math.ceil(otherPost.body.split(/\s+/).length / 200);
-								const otherDate = otherPost.data.publishDate.toLocaleDateString("nl-NL", {
-									year: "numeric",
-									month: "short",
-									day: "numeric",
-								});
-								return (
-									<a href={`/blog/${otherPost.slug}/`} class="group block py-4 border-b border-ink/10 hover:border-ink/20 transition-colors">
-										<h3 class="text-lg font-semibold text-ink leading-tight mb-2 group-hover:text-ink/70 transition-colors">
-											{otherPost.data.title}
-										</h3>
-										<p class="text-ink/60 text-sm leading-relaxed mb-2 line-clamp-2">
-											{otherPost.data.description}
-										</p>
-										<div class="flex items-center gap-2 text-xs text-ink/40">
-											<time datetime={otherPost.data.publishDate.toISOString()}>
-												{otherDate}
-											</time>
-											<span>&middot;</span>
-											<span>{otherReadingTime} min</span>
-										</div>
-									</a>
-								);
-							})}
+					<div class="max-w-3xl mx-auto">
+						<h2 class="text-2xl font-bold mb-8">Verder lezen?</h2>
+						<div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+							{otherPosts.map((otherPost) => (
+								<BlogCardImage
+									title={otherPost.data.title}
+									description={otherPost.data.description}
+									publishDate={otherPost.data.publishDate}
+									slug={otherPost.slug}
+									image={otherPost.data.image}
+									imageAlt={otherPost.data.imageAlt}
+									tags={otherPost.data.tags}
+									readingTime={otherPost.data.readingTime}
+								/>
+							))}
 						</div>
 					</div>
 				</section>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -2,6 +2,7 @@
 import Layout from "../../layouts/Layout.astro";
 import Footer from "../../components/Footer.astro";
 import BlogCard from "../../components/blog/BlogCard.astro";
+import BlogCardImage from "../../components/blog/BlogCardImage.astro";
 import BreadcrumbSchema from "../../components/seo/BreadcrumbSchema.astro";
 import { getCollection } from "astro:content";
 
@@ -16,6 +17,10 @@ const sortedPosts = allPosts.sort(
 // Separate featured post (most recent) from the rest
 const featuredPost = sortedPosts[0];
 const remainingPosts = sortedPosts.slice(1);
+
+// Split remaining posts: first 4 get image grid, rest get compact list
+const gridPosts = remainingPosts.slice(0, 4);
+const listPosts = remainingPosts.slice(4);
 
 // Extract unique tags for filtering
 const allTags = [...new Set(sortedPosts.flatMap((post) => post.data.tags))].sort();
@@ -135,12 +140,34 @@ const breadcrumbs = [
 			</section>
 		)}
 
-		<!-- Blog Posts List -->
-		<section class="py-8 md:py-12 bg-canvas">
-			<div class="max-w-3xl mx-auto px-6 md:px-12 lg:px-16">
-				{remainingPosts.length > 0 ? (
+		<!-- Image Grid Posts -->
+		{gridPosts.length > 0 && (
+			<section class="pb-8 md:pb-12 bg-canvas">
+				<div class="max-w-3xl mx-auto px-6 md:px-12 lg:px-16">
+					<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+						{gridPosts.map((post) => (
+							<BlogCardImage
+								title={post.data.title}
+								description={post.data.description}
+								publishDate={post.data.publishDate}
+								slug={post.slug}
+								image={post.data.image}
+								imageAlt={post.data.imageAlt}
+								tags={post.data.tags}
+								readingTime={post.data.readingTime}
+							/>
+						))}
+					</div>
+				</div>
+			</section>
+		)}
+
+		<!-- Compact Blog Posts List -->
+		{listPosts.length > 0 && (
+			<section class="py-8 md:py-12 bg-canvas">
+				<div class="max-w-3xl mx-auto px-6 md:px-12 lg:px-16">
 					<div class="space-y-6">
-						{remainingPosts.map((post) => (
+						{listPosts.map((post) => (
 							<BlogCard
 								title={post.data.title}
 								description={post.data.description}
@@ -151,15 +178,20 @@ const breadcrumbs = [
 							/>
 						))}
 					</div>
-				) : sortedPosts.length === 0 ? (
-					<div class="text-center py-16">
-						<p class="text-ink/60 text-lg">
-							Binnenkort verschijnen hier onze eerste artikelen.
-						</p>
-					</div>
-				) : null}
-			</div>
-		</section>
+				</div>
+			</section>
+		)}
+
+		<!-- Empty State -->
+		{sortedPosts.length === 0 && (
+			<section class="py-16 bg-canvas">
+				<div class="max-w-3xl mx-auto px-6 md:px-12 lg:px-16 text-center">
+					<p class="text-ink/60 text-lg">
+						Binnenkort verschijnen hier onze eerste artikelen.
+					</p>
+				</div>
+			</section>
+		)}
 
 		<Footer />
 	</main>


### PR DESCRIPTION
## Summary
- Add `BlogCardImage` component with thumbnail images, tags, and meta info
- Blog overview (`/blog/`): 3-tier visual hierarchy — hero card → 2-column image grid → compact text list
- Blog posts (`/blog/[slug]/`): rename "Meer artikelen" to "Verder lezen?" with 3-column image cards

Closes #221

## Test plan
- [ ] Visit `/blog/` — verify featured hero card unchanged, next 4 posts show as image grid, remaining posts as text list
- [ ] Verify responsive layout: 1-col on mobile, 2-col grid on md+
- [ ] Visit any blog post — verify "Verder lezen?" section shows 3 image cards
- [ ] Check lazy loading on grid images (not eager)

🤖 Generated with [Claude Code](https://claude.com/claude-code)