### PR TITLE
fix: ICS calendar not loading in Gmail

### DIFF
--- a/src/lib/email-templates.ts
+++ b/src/lib/email-templates.ts
@@ -227,7 +227,7 @@ export function buildICSContent(data: AanvraagData, isInternal: boolean): string
     'END:VCALENDAR',
   ];
 
-  return lines.join('\r\n');
+  return lines.join('\r\n') + '\r\n';
 }
 
 // ─── Contextual questions ────────────────────────────────

--- a/src/pages/api/submissions/index.ts
+++ b/src/pages/api/submissions/index.ts
@@ -48,6 +48,7 @@ function normalizeUrl(url: string): string | null {
 interface EmailAttachment {
   filename: string;
   content: string; // base64
+  content_type?: string;
 }
 
 async function sendEmail(apiKey: string, to: string, subject: string, html: string, replyTo?: string, attachments?: EmailAttachment[]) {
@@ -242,10 +243,12 @@ export const POST: APIRoute = async ({ request, locals }) => {
         const icsAttachment = aanvraagData.start_time ? [{
           filename: 'invite.ics',
           content: btoa(buildICSContent(aanvraagData, false)),
+          content_type: 'text/calendar; method=REQUEST',
         }] : undefined;
         const icsAttachmentInternal = aanvraagData.start_time ? [{
           filename: 'invite.ics',
           content: btoa(buildICSContent(aanvraagData, true)),
+          content_type: 'text/calendar; method=REQUEST',
         }] : undefined;
         // Notification to Yannick
         const dateStr = aanvraagData.start_time


### PR DESCRIPTION
## Summary
- Added `content_type: 'text/calendar; method=REQUEST'` to ICS attachments
- Added trailing CRLF to ICS content (required by RFC 5545)
- Fixes "Unable to load event" in Gmail

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)