### PR TITLE
fix: improve mobile scroll animation trigger on Jonkers page

### DIFF
--- a/src/pages/klant/jonkers.astro
+++ b/src/pages/klant/jonkers.astro
@@ -1372,7 +1372,7 @@ export const prerender = true;
         }
       });
     },
-    { threshold: 0.1, rootMargin: '0px 0px -50px 0px' }
+    { threshold: 0, rootMargin: '0px 0px -20px 0px' }
   );
 
   document.querySelectorAll('.fade-in').forEach((el) => {


### PR DESCRIPTION
## Summary
- Lower `IntersectionObserver` threshold from `0.1` to `0` so tall sections animate in immediately when they enter the viewport
- Reduce negative `rootMargin` from `-50px` to `-20px` to avoid edge-case jank

**Root cause:** `threshold: 0.1` fires when 10% of the element is visible. For very tall sections (like the first chapter), that's 100–200px of content — far more scrolling than expected on mobile.

## Test plan
- [ ] Open Jonkers page on mobile
- [ ] Scroll through — all sections should fade in as soon as they come into view
- [ ] First chapter section should animate without extra scrolling

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)