### PR TITLE
fix: allow AI crawlers to index Jonkers client page

### DIFF
--- a/src/pages/klant/jonkers.astro
+++ b/src/pages/klant/jonkers.astro
@@ -7,9 +7,9 @@ export const prerender = true;
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="robots" content="noindex, nofollow, noarchive, noimageindex, nosnippet">
+  <!-- Block traditional search indexing, but allow AI crawlers (GPTBot, ClaudeBot, PerplexityBot, Google-Extended) -->
   <meta name="googlebot" content="noindex, nofollow, noarchive, noimageindex, nosnippet">
-  <meta name="bingbot" content="noindex, nofollow">
+  <meta name="bingbot" content="noindex, nofollow, noarchive, noimageindex, nosnippet">
   <title>Jonkers Groep: Plan voor Online Zichtbaarheid — KNAP GEMAAKT.</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- Remove `<meta name="robots" content="noindex">` general catch-all
- Keep `googlebot` and `bingbot` specific blocks so page stays out of Google/Bing search
- GPTBot, ClaudeBot, PerplexityBot, and Google-Extended (Gemini) can now crawl and summarize the page

## Test plan
- [ ] Google Search still cannot index the page (googlebot meta remains)
- [ ] Paste URL into ChatGPT, Claude, Perplexity — all can read and summarize content

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)