### PR TITLE
fix: restore noindex on Jonkers page for all crawlers

### DIFF
--- a/src/pages/klant/jonkers.astro
+++ b/src/pages/klant/jonkers.astro
@@ -7,9 +7,9 @@ export const prerender = true;
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <!-- Block traditional search indexing, but allow AI crawlers (GPTBot, ClaudeBot, PerplexityBot, Google-Extended) -->
+  <meta name="robots" content="noindex, nofollow, noarchive, noimageindex, nosnippet">
   <meta name="googlebot" content="noindex, nofollow, noarchive, noimageindex, nosnippet">
-  <meta name="bingbot" content="noindex, nofollow, noarchive, noimageindex, nosnippet">
+  <meta name="bingbot" content="noindex, nofollow">
   <title>Jonkers Groep: Plan voor Online Zichtbaarheid — KNAP GEMAAKT.</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- Restores `<meta name="robots" content="noindex">` removed in #244
- noindex doesn't affect live URL summarization — ChatGPT/Claude/Gemini/Perplexity fetch pages directly when given a URL regardless of this tag
- Without it, DuckDuckGo/Yandex/etc. could index the confidential client page

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)