### PR TITLE
fix: correct Dutch copy and link destinations on Jonkers page

### DIFF
--- a/src/pages/klant/jonkers.astro
+++ b/src/pages/klant/jonkers.astro
@@ -886,22 +886,22 @@ export const prerender = true;
         <div class="ways-grid" style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;">
           <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1.25rem;">
             <div style="font-weight:700;color:var(--accent);font-size:0.8125rem;text-transform:uppercase;letter-spacing:0.06em;margin-bottom:0.5rem;">Video op social media</div>
-            <p style="font-size:0.875rem;color:var(--ink-2);margin:0;line-height:1.6;">Korte video's van afgeronde projecten op Instagram en TikTok. Mensen zien het resultaat, klikken door naar de Tuinprijscheck, en boeken een tuinscan.</p>
+            <p style="font-size:0.875rem;color:var(--ink-2);margin:0;line-height:1.6;">Korte video's van afgeronde projecten op Instagram en TikTok. Mensen zien het resultaat, klikken op de link in bio, en komen op de Tuinprijscheck landingspagina.</p>
           </div>
 
           <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1.25rem;">
             <div style="font-weight:700;color:var(--accent);font-size:0.8125rem;text-transform:uppercase;letter-spacing:0.06em;margin-bottom:0.5rem;">Buren van een project</div>
-            <p style="font-size:0.875rem;color:var(--ink-2);margin:0;line-height:1.6;">Een bord bij elke klus en handgeschreven briefjes aan de buren. Ze scannen de QR-code, komen op de Tuinprijscheck, en boeken een tuinscan.</p>
+            <p style="font-size:0.875rem;color:var(--ink-2);margin:0;line-height:1.6;">Een bord bij elke klus (linkt naar de homepage) en handgeschreven briefjes aan de buren. Ze bellen direct of bezoeken de website.</p>
           </div>
 
           <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1.25rem;">
             <div style="font-weight:700;color:var(--accent);font-size:0.8125rem;text-transform:uppercase;letter-spacing:0.06em;margin-bottom:0.5rem;">Doorverwijzingen</div>
-            <p style="font-size:0.875rem;color:var(--ink-2);margin:0;line-height:1.6;">Tevreden klanten krijgen kaartjes om door te geven. Nieuwe klant krijgt €100 korting, doorverwijzer krijgt een cadeaubon.</p>
+            <p style="font-size:0.875rem;color:var(--ink-2);margin:0;line-height:1.6;">Tevreden klanten krijgen kaartjes om door te geven. Nieuwe klant krijgt €100 korting, doorverwijzer krijgt een cadeaubon. De meesten zullen gewoon bellen.</p>
           </div>
 
           <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1.25rem;">
             <div style="font-weight:700;color:var(--accent);font-size:0.8125rem;text-transform:uppercase;letter-spacing:0.06em;margin-bottom:0.5rem;">B2B schroeffunderingen</div>
-            <p style="font-size:0.875rem;color:var(--ink-2);margin:0;line-height:1.6;">Hoveniers en aannemers die zelf geen funderingen plaatsen. Jonkers legt de fundering, zij bouwen erop.</p>
+            <p style="font-size:0.875rem;color:var(--ink-2);margin:0;line-height:1.6;">Hoveniers en aannemers die zelf geen funderingen plaatsen. Jonkers legt de fundering, zij bouwen erop. Contact gaat via telefoon of LinkedIn.</p>
           </div>
 
           <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1.25rem;">
@@ -911,11 +911,11 @@ export const prerender = true;
 
           <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1.25rem;">
             <div style="font-weight:700;color:var(--accent);font-size:0.8125rem;text-transform:uppercase;letter-spacing:0.06em;margin-bottom:0.5rem;">Google Reviews</div>
-            <p style="font-size:0.875rem;color:var(--ink-2);margin:0;line-height:1.6;">Goede reviews zorgen voor een hogere positie in Google Maps. Na elke klus vraagt Arno om een review.</p>
+            <p style="font-size:0.875rem;color:var(--ink-2);margin:0;line-height:1.6;">Goede reviews zorgen voor een hogere positie in Google Maps. Mensen die op Google zoeken komen via het profiel op de homepage.</p>
           </div>
         </div>
 
-        <p style="font-size:0.875rem;color:var(--ink-3);margin-top:0.75rem;">Alle paden komen uit bij de Tuinprijscheck. Daar boekt de klant een tuinscan, en tijdens die tuinscan sluit Arno af met een voorstel in drie opties.</p>
+        <p style="font-size:0.875rem;color:var(--ink-3);margin-top:0.75rem;">Uiteindelijk boekt iemand een tuinscan. Tijdens die tuinscan doet Arno ter plekke een voorstel in drie opties.</p>
       </div>
     </header>
 
@@ -1323,7 +1323,7 @@ export const prerender = true;
     <!-- 9. TUINPRIJSCHECK -->
     <section id="tuinprijscheck">
       <h2>9. De Tuinprijscheck</h2>
-      <p>Alles wat in Deel 1 staat dient één doel: mensen naar de Tuinprijscheck sturen. Elke aanvraag, of die nu via video, Google, buurt, doorverwijzing of B2B binnenkomt, komt hier uit.</p>
+      <p>Alles wat in Deel 1 staat dient één doel: zorgen dat mensen contact opnemen. Sommige kanalen leiden naar de Tuinprijscheck landingspagina, andere naar de homepage, en soms belt iemand gewoon direct.</p>
 
       <div class="funnel">
         <div class="funnel-sources">
@@ -1459,12 +1459,12 @@ export const prerender = true;
       <ul>
         <li>"Wat stoort je het meest aan je tuin nu?"</li>
         <li>"Wat wil je in deze ruimte doen over twee jaar?"</li>
-        <li>"Heb je al een bedrag in gedachten, of begint dat te leven?"</li>
+        <li>"Heb je al een bedrag in gedachten, of is dat nog lastig te zeggen?"</li>
       </ul>
       <p>Het bezoek levert altijd drie concrete aanbevelingen op, ook als de klant geen project wordt. Die vrijgevigheid is wat werkt. Geen verkooppraatje.</p>
 
-      <h3>9.8 Afsluiten ter plekke</h3>
-      <p>Arno sluit af tijdens de tuinscan, niet erna. Aan het einde van het bezoek laat hij een eenvoudig document zien (geprint of op zijn telefoon) met drie opties:</p>
+      <h3>9.8 Voorstel doen ter plekke</h3>
+      <p>Arno doet zijn voorstel tijdens de tuinscan, niet achteraf. Aan het einde van het bezoek laat hij een eenvoudig document zien (geprint of op zijn telefoon) met drie opties:</p>
 
       <div class="pricing-grid">
         <div class="price-card">
@@ -1484,7 +1484,7 @@ export const prerender = true;
         </div>
       </div>
 
-      <p>De klant hoeft niet ja of nee te zeggen, hij kiest een niveau. Dat maakt het ook minder nodig om bij andere hoveniers te vergelijken. Eén bezoek, één voorstel, één beslissing.</p>
+      <p>De klant hoeft niet ja of nee te zeggen, hij kiest een niveau. Dat maakt het ook minder nodig om bij andere hoveniers te vergelijken. Eén bezoek, één voorstel, één besluit.</p>
     </section>
 
     <!-- 10. LEADGEN A: VIDEO -->
@@ -1541,17 +1541,17 @@ export const prerender = true;
 
       <h3>12.1 Bouwbord</h3>
       <p>Een stevig bord bij elke klus, van start tot 1–2 weken na oplevering. Verwerk bord-toestemming als standaardclausule in elk projectcontract.</p>
-      <p><strong>Inhoud:</strong> Bedrijfsnaam, website-URL, QR-code naar de Tuinprijscheck. Leesbaar in 3 seconden op 25–50 meter afstand.</p>
+      <p><strong>Inhoud:</strong> Bedrijfsnaam, website-URL, QR-code naar de homepage. Leesbaar in 3 seconden op 25–50 meter afstand.</p>
 
       <h3>12.2 Handgeschreven buurtbriefjes</h3>
       <p>Binnen 3 dagen na oplevering: 15–20 handgeschreven briefjes aan de dichtstbijzijnde woningen. Niet een geprinte flyer, maar handgeschreven op een merkkaartje. Openingspercentage handgeschreven: 90–99% versus 42% voor geprint.</p>
       <blockquote>
         <p>Geachte buurman/buurvrouw, ik heb afgelopen week de tuin mogen aanleggen op nummer [X]. Mocht u ooit vragen hebben over uw eigen tuin, kijk dan gerust op de achterkant voor meer informatie. Geen verplichtingen, gewoon een kennismaking. Met vriendelijke groet, Arno Jonkers — Hoveniersbedrijf Jonkers</p>
       </blockquote>
-      <p><strong>Achterkant:</strong> website URL + QR-code naar Tuinprijscheck + telefoonnummer. Respecteer NEE/NEE en NEE/JA stickers op brievenbussen.</p>
+      <p><strong>Achterkant:</strong> website URL + QR-code naar de homepage + telefoonnummer. Respecteer NEE/NEE en NEE/JA stickers op brievenbussen.</p>
 
       <h3>12.3 Flow</h3>
-      <p>Project opgeleverd, bord omhoog + 15–20 briefjes, QR scan, Tuinprijscheck, zelfde flow. Of: direct bellen, Arno stelt tuinscan voor.</p>
+      <p>Project opgeleverd, bord omhoog + 15–20 briefjes. Buren bezoeken de homepage of bellen direct. Arno stelt een tuinscan voor.</p>
     </section>
 
     <!-- 13. LEADGEN D: DOORVERWIJZINGEN -->


### PR DESCRIPTION
## Summary
- "Afsluiten" → "voorstel doen" (afsluiten = closing a door, not closing a deal)
- "Begint te leven" → "is dat nog lastig te zeggen" (nonsense translation removed)
- Bord QR-code → homepage (not Tuinprijscheck landing page)
- Buurtbriefjes achterkant → homepage (not Tuinprijscheck)
- Doorverwijzingen: added "de meesten zullen gewoon bellen"
- B2B: added "contact gaat via telefoon of LinkedIn"
- Google Reviews: profile links to homepage
- Intro text: accurate about different channels going to different destinations

## Test plan
- [ ] Read through sections 9.7, 9.8, 12, 13, 14 for natural Dutch
- [ ] Verify no remaining "afsluiten" in deal-closing context

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)