### PR TITLE
fix: align booking hours with GBP business hours

### DIFF
--- a/src/config/availability.json
+++ b/src/config/availability.json
@@ -1,12 +1,12 @@
 {
   "businessHours": {
-    "monday": { "enabled": true, "start": "08:00", "end": "20:00" },
-    "tuesday": { "enabled": true, "start": "08:00", "end": "20:00" },
-    "wednesday": { "enabled": true, "start": "08:00", "end": "20:00" },
-    "thursday": { "enabled": true, "start": "08:00", "end": "20:00" },
-    "friday": { "enabled": true, "start": "08:00", "end": "20:00" },
-    "saturday": { "enabled": true, "start": "08:00", "end": "20:00" },
-    "sunday": { "enabled": true, "start": "08:00", "end": "20:00" }
+    "monday": { "enabled": true, "start": "08:00", "end": "19:00" },
+    "tuesday": { "enabled": true, "start": "08:00", "end": "19:00" },
+    "wednesday": { "enabled": true, "start": "08:00", "end": "19:00" },
+    "thursday": { "enabled": true, "start": "08:00", "end": "19:00" },
+    "friday": { "enabled": true, "start": "08:00", "end": "19:00" },
+    "saturday": { "enabled": true, "start": "08:00", "end": "17:00" },
+    "sunday": { "enabled": true, "start": "08:00", "end": "19:00" }
   },
   "slotDuration": 15,
   "bufferTime": 0,


### PR DESCRIPTION
## Summary
- Reduces booking end times from 20:00 to 19:00 (Mon–Fri + Sun) and 17:00 (Saturday)
- Prevents late evening bookings (19:30, 19:45) when calendar is empty
- Matches Google Business Profile hours shown on aanvragen page

## Test plan
- [ ] Verify Saturday shows last slot at 16:45
- [ ] Verify weekdays show last slot at 18:45
- [ ] Verify no slots appear after closing time

Closes #249

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)