### PR TITLE
fix: update redirect destinations for old page URLs

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -15,8 +15,8 @@
 # Blog post redirects (consolidated content)
 /blog/webdesign-utrecht /blog/website-laten-maken-kosten/ 301
 /blog/webdesign-utrecht/ /blog/website-laten-maken-kosten/ 301
-/blog/webshop-laten-maken /blog/website-laten-maken-kosten/ 301
-/blog/webshop-laten-maken/ /blog/website-laten-maken-kosten/ 301
+/blog/webshop-laten-maken /webshops/ 301
+/blog/webshop-laten-maken/ /webshops/ 301
 /blog/maatwerkwebsite-laten-maken /blog/website-laten-maken-kosten/ 301
 /blog/maatwerkwebsite-laten-maken/ /blog/website-laten-maken-kosten/ 301
 /blog/zelf-website-maken-of-laten-maken /blog/website-laten-maken-kosten/ 301
@@ -27,8 +27,8 @@
 /project/schildersbedrijf-visser/ /werk/ 301
 
 # Redesign redirects (old pages -> new pages)
-/website-laten-maken /ict-diensten/ 301
-/website-laten-maken/ /ict-diensten/ 301
+/website-laten-maken /webdesign/ 301
+/website-laten-maken/ /webdesign/ 301
 /automations /ict-diensten/ 301
 /automations/ /ict-diensten/ 301
 /portfolio /werk/ 301


### PR DESCRIPTION
## Summary
- `/website-laten-maken/` now redirects to `/webdesign/` (was `/ict-diensten/`)
- `/blog/webshop-laten-maken/` now redirects to `/webshops/` (was `/blog/website-laten-maken-kosten/`)

## Test plan
- [ ] Verify `/website-laten-maken/` 301s to `/webdesign/`
- [ ] Verify `/blog/webshop-laten-maken/` 301s to `/webshops/`

Closes #251

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)