### PR TITLE
fix: route plan page emails through n8n

### DIFF
--- a/src/pages/api/submissions/index.ts
+++ b/src/pages/api/submissions/index.ts
@@ -239,7 +239,9 @@ export const POST: APIRoute = async ({ request, locals }) => {
         );
       }
     } else if (body.type === 'aanvraag') {
-      if (apiKey) {
+      // When meeting_type is set (from /plan/ page), n8n handles emails
+      // (it has the meeting link). Skip API emails for those bookings.
+      if (apiKey && !body.meeting_type) {
         const aanvraagData = { ...body, booking_id: bookingId || undefined, start_time: bookingStartTime || body.start_time };
         // Build ICS calendar attachments
         const icsAttachment = aanvraagData.start_time ? [{


### PR DESCRIPTION
## Summary
- Skip API-sent confirmation emails when `meeting_type` is set (from /plan/ page)
- n8n now handles these emails and includes the Google Meet link

## Test plan
- [ ] Book via /plan/ with Google Meet → confirmation email has Meet link
- [ ] Book via /plan/ with Phone → confirmation email mentions phone
- [ ] Book via /aanvragen/ → existing emails still work (no meeting_type)