### PR TITLE
fix: remove duplicate FAQPage JSON-LD on /webdesign/

### DIFF
--- a/src/components/FAQSection.astro
+++ b/src/components/FAQSection.astro
@@ -1,12 +1,8 @@
 ---
 /**
- * FAQSection, visual FAQ accordion + JSON-LD schema
- *
- * Uses native <details>/<summary> for zero-JS accordion behavior.
- * Automatically includes FAQSchema for structured data.
+ * FAQSection, visual FAQ accordion (zero-JS, <details>/<summary>).
+ * Does NOT emit JSON-LD — render <FAQSchema> explicitly in the page frontmatter.
  */
-
-import FAQSchema from "./seo/FAQSchema.astro";
 
 interface FAQItem {
 	question: string;
@@ -20,8 +16,6 @@ interface Props {
 
 const { faqs, heading = "Veelgestelde vragen" } = Astro.props;
 ---
-
-<FAQSchema faqs={faqs} />
 
 <section class="py-16 md:py-24 px-6 md:px-12 lg:px-16">
 	<div class="max-w-3xl mx-auto">


### PR DESCRIPTION
## Summary
- GSC flagged `/webdesign/` for duplicate `FAQPage` schema (2 affected items)
- Root cause: `FAQSection.astro` silently rendered `<FAQSchema>` internally, while `webdesign.astro` also rendered `<FAQSchema>` explicitly in frontmatter
- Removed the auto-injection from `FAQSection` so it is purely visual; pages emit `FAQSchema` explicitly (matches the pattern already used by every other page)

## Test plan
- [x] Verified `FAQSection` is only used on `webdesign.astro` (no other callers lose schema)
- [x] Confirmed `webdesign.astro:69` still emits `<FAQSchema>` once
- [ ] After deploy: hit "Validate fix" in Search Console → FAQ → Duplicate field "FAQPage"

🤖 Generated with [Claude Code](https://claude.com/claude-code)