### PR TITLE
fix: re-decode CF email obfuscation after View Transitions

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -141,6 +141,23 @@ const ogImageURL = new URL(image, Astro.site);
           });
         }
       });
+      // Re-decode Cloudflare email obfuscation after View Transition navigations
+      document.addEventListener('astro:page-load', () => {
+        document.querySelectorAll('.__cf_email__').forEach((el) => {
+          const encoded = el.getAttribute('data-cfemail');
+          if (!encoded) return;
+          const key = parseInt(encoded.substr(0, 2), 16);
+          let decoded = '';
+          for (let i = 2; i < encoded.length; i += 2) {
+            decoded += String.fromCharCode(parseInt(encoded.substr(i, 2), 16) ^ key);
+          }
+          el.textContent = decoded;
+          const link = el.closest('a');
+          if (link && link.href.includes('/cdn-cgi/l/email-protection')) {
+            link.href = 'mailto:' + decoded;
+          }
+        });
+      });
     </script>
 
     <!-- Contact Widget (client:idle defers hydration to improve LCP/FCP) -->


### PR DESCRIPTION
## Summary
- Cloudflare's email-protection decoder only runs on initial `DOMContentLoaded`, so client-side View Transition navigations leave `[email&nbsp;protected]` placeholders visible until a hard refresh.
- Adds an `astro:page-load` listener in `Layout.astro` that decodes `.__cf_email__` elements and rewrites the parent `mailto:` link on every navigation.
- Same fix as the Serenitas project (commit `6395461`).

## Test plan
- [ ] Deploy and navigate from any page to one containing the email — address renders immediately, no hard refresh required.
- [ ] Initial page load (cold) still shows the decoded address.