### PR TITLE
fix(turnstile): replace invalid size='invisible' with appearance='interaction-only'

### DIFF
--- a/src/components/BookingFlow.tsx
+++ b/src/components/BookingFlow.tsx
@@ -227,7 +227,6 @@ export default function BookingFlow() {
         win.turnstile.render(turnstileRef.current, {
           sitekey: '0x4AAAAAACzkKUPSoLBK6a1f',
           theme: 'dark',
-          size: 'invisible',
           appearance: 'interaction-only',
         });
       }

--- a/src/pages/aanvragen.astro
+++ b/src/pages/aanvragen.astro
@@ -304,7 +304,7 @@ import Footer from "../components/Footer.astro";
                 </div>
 
                 <!-- Turnstile (invisible CAPTCHA) -->
-                <div class="cf-turnstile" data-sitekey="0x4AAAAAACzkKUPSoLBK6a1f" data-theme="light" data-size="flexible"></div>
+                <div class="cf-turnstile" data-sitekey="0x4AAAAAACzkKUPSoLBK6a1f" data-theme="light" data-appearance="interaction-only"></div>
 
                 <!-- Submit -->
                 <div class="pt-8">

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -165,7 +165,7 @@ import FadeIn from "../components/FadeIn.astro";
 						</div>
 
 						<!-- Turnstile (invisible CAPTCHA) -->
-						<div class="cf-turnstile" data-sitekey="0x4AAAAAACzkKUPSoLBK6a1f" data-theme="light" data-size="flexible"></div>
+						<div class="cf-turnstile" data-sitekey="0x4AAAAAACzkKUPSoLBK6a1f" data-theme="light" data-appearance="interaction-only"></div>
 
 						<!-- Submit -->
 						<button


### PR DESCRIPTION
## Summary
- `/plan/` (`BookingFlow.tsx`) was passing `size: 'invisible'` to `turnstile.render()`, which Cloudflare rejects (valid sizes: `compact`, `flexible`, `normal`). Threw a console error on every booking form load. Removed the param.
- `/aanvragen/` and `/contact/` were using `data-size="flexible"` with a misleading "invisible CAPTCHA" comment. Replaced with `data-appearance="interaction-only"` so the widget stays hidden for legitimate visitors and only appears when a real challenge is needed, matching `/plan/` behavior.

The sitekey is Managed mode (verified via CF API). `appearance: 'interaction-only'` is the correct mechanism for invisible-feeling UX on a Managed-mode sitekey.

## Test plan
- [ ] Open `/plan/` → step through to the form → confirm no Turnstile console error
- [ ] Open `/aanvragen/` → confirm Turnstile widget no longer renders visibly above the submit button
- [ ] Open `/contact/` → confirm Turnstile widget no longer renders visibly above the submit button
- [ ] Submit each form with valid input → confirm `cf-turnstile-response` token is still sent and server-side verification passes